### PR TITLE
OCR & clipboard images, allow duplicates, defaulted settings.

### DIFF
--- a/ClipboardManager/CHANGELOG.md
+++ b/ClipboardManager/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Change log
-## Changes
-- New way to display messages.
-
 ## New
-- Clipboard triggers now show if the format string is invalid, same for the regex string.
-- If a trigger doesn't have a valid format string, a message will be shown to the user.
+- Clipboard history will now show images stored in the clipboard.
+- OCR will be performed on images stored in the clipboard and when an image is copied into it. If the text matches a trigger, matching actions will be created.
+
+## Changes
+- Implemented "Add duplicated actions" toggle in settings page.
+- Fixed mismatch between settings defaulting "Allow notifications" to true and the rest of the application defaulting to false.
+- Now defaulting "Add duplicated actions" to true.
 
 ## Bugs
 
@@ -29,3 +31,4 @@
     - [X] TriggerError_FailedToReload
 
 - [ ] Add format checking/validation for `ClipboardActionView`.
+- [ ] Implement copy and pin buttons for clipboard history items.

--- a/ClipboardManager/ClipboardHistoryItemView.cpp
+++ b/ClipboardManager/ClipboardHistoryItemView.cpp
@@ -1,0 +1,19 @@
+#include "pch.h"
+#include "ClipboardHistoryItemView.h"
+#if __has_include("ClipboardHistoryItemView.g.cpp")
+#include "ClipboardHistoryItemView.g.cpp"
+#endif
+
+
+namespace winrt::ClipboardManager::implementation
+{
+    void ClipboardHistoryItemView::HostContent(const Windows::Foundation::IInspectable& value)
+    {
+        _hostContent = value;
+    }
+
+    Windows::Foundation::IInspectable ClipboardHistoryItemView::HostContent() const
+    {
+        return _hostContent;
+    }
+}

--- a/ClipboardManager/ClipboardHistoryItemView.h
+++ b/ClipboardManager/ClipboardHistoryItemView.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "ClipboardHistoryItemView.g.h"
+
+namespace winrt::ClipboardManager::implementation
+{
+    struct ClipboardHistoryItemView : ClipboardHistoryItemViewT<ClipboardHistoryItemView>
+    {
+    public:
+        ClipboardHistoryItemView() = default;
+
+        void HostContent(const Windows::Foundation::IInspectable& value);
+        Windows::Foundation::IInspectable HostContent() const;
+
+    private:
+        Windows::Foundation::IInspectable _hostContent{};
+    };
+}
+
+namespace winrt::ClipboardManager::factory_implementation
+{
+    struct ClipboardHistoryItemView : ClipboardHistoryItemViewT<ClipboardHistoryItemView, implementation::ClipboardHistoryItemView>
+    {
+    };
+}

--- a/ClipboardManager/ClipboardHistoryItemView.idl
+++ b/ClipboardManager/ClipboardHistoryItemView.idl
@@ -1,0 +1,10 @@
+namespace ClipboardManager
+{
+    [default_interface]
+    runtimeclass ClipboardHistoryItemView : Microsoft.UI.Xaml.Controls.UserControl
+    {
+        ClipboardHistoryItemView();
+
+        IInspectable HostContent;
+    }
+}

--- a/ClipboardManager/ClipboardHistoryItemView.xaml
+++ b/ClipboardManager/ClipboardHistoryItemView.xaml
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="ClipboardManager.ClipboardHistoryItemView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:ClipboardManager"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid 
+        Background="{ThemeResource SolidBackgroundFillColorTertiaryBrush}" 
+        CornerRadius="{StaticResource OverlayCornerRadius}" 
+        BorderBrush="{ThemeResource ExpanderHeaderBorderBrush}"
+        BorderThickness="1" 
+        Padding="7,5" 
+        Margin="0,3,0,3">
+        <Grid.Transitions>
+            <TransitionCollection>
+                <RepositionThemeTransition/>
+            </TransitionCollection>
+        </Grid.Transitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.Resources>
+            <Style TargetType="TextBlock">
+                <Setter Property="IsTextSelectionEnabled" Value="True"/>
+            </Style>
+        </Grid.Resources>
+
+        <ContentPresenter Content="{x:Bind HostContent}" Grid.Column="0" MaxHeight="500"/>
+
+        <StackPanel Grid.Column="1" Grid.RowSpan="2" Orientation="Vertical" Spacing="5">
+            <Button Style="{StaticResource IconButtonStyle}">
+                <FontIcon Glyph="&#xe8c8;" FontSize="14"/>
+            </Button>
+            <Button Style="{StaticResource IconButtonStyle}">
+                <FontIcon Glyph="&#xe718;" FontSize="14"/>
+            </Button>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/ClipboardManager/ClipboardManager.vcxproj
+++ b/ClipboardManager/ClipboardManager.vcxproj
@@ -179,6 +179,7 @@
       <SubType>Code</SubType>
     </ClInclude>
     <ClInclude Include="src\implementation\VisualStateManager_implementation.hpp" />
+    <ClInclude Include="src\utils\com_closable_ptr.h" />
     <ClInclude Include="src\utils\ResLoader.hpp" />
     <ClInclude Include="src\ui\ListenablePropertyValue.hpp" />
     <ClInclude Include="src\utils\Launcher.hpp" />

--- a/ClipboardManager/ClipboardManager.vcxproj
+++ b/ClipboardManager/ClipboardManager.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.WindowsAppSDK.1.5.240627000\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.5.240627000\build\native\Microsoft.WindowsAppSDK.props')" />
+  <Import Project="..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.props" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.props')" />
   <Import Project="..\packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1\build\Microsoft.Windows.SDK.BuildTools.props" Condition="Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1\build\Microsoft.Windows.SDK.BuildTools.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -161,6 +161,10 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="ClipboardHistoryItemView.h">
+      <DependentUpon>ClipboardHistoryItemView.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="src\FormatExceptionCode.hpp" />
     <ClInclude Include="MessagesBar.h">
       <DependentUpon>MessagesBar.xaml</DependentUpon>
@@ -225,6 +229,10 @@
     <ClInclude Include="src\notifs\ToastNotificationHandler.hpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="ClipboardHistoryItemView.cpp">
+      <DependentUpon>ClipboardHistoryItemView.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="src\FormatExceptionCode.cpp" />
     <ClCompile Include="MessagesBar.cpp">
       <DependentUpon>MessagesBar.xaml</DependentUpon>
@@ -318,6 +326,10 @@
       <DependentUpon>ClipboardActionView.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Midl>
+    <Midl Include="ClipboardHistoryItemView.idl">
+      <DependentUpon>ClipboardHistoryItemView.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Midl>
     <Midl Include="HostControl.idl">
       <DependentUpon>HostControl.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -350,6 +362,9 @@
     <Page Include="ClipboardActionView.xaml">
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="ClipboardHistoryItemView.xaml">
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="HostControl.xaml">
       <SubType>Designer</SubType>
     </Page>
@@ -380,11 +395,12 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\boost.1.85.0\build\boost.targets" Condition="Exists('..\packages\boost.1.85.0\build\boost.targets')" />
-    <Import Project="..\packages\boost_regex-vc143.1.85.0\build\boost_regex-vc143.targets" Condition="Exists('..\packages\boost_regex-vc143.1.85.0\build\boost_regex-vc143.targets')" />
-    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
     <Import Project="..\packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1\build\Microsoft.Windows.SDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1\build\Microsoft.Windows.SDK.BuildTools.targets')" />
-    <Import Project="..\packages\Microsoft.WindowsAppSDK.1.5.240627000\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.5.240627000\build\native\Microsoft.WindowsAppSDK.targets')" />
+    <Import Project="..\packages\boost.1.86.0\build\boost.targets" Condition="Exists('..\packages\boost.1.86.0\build\boost.targets')" />
+    <Import Project="..\packages\boost_regex-vc143.1.86.0\build\boost_regex-vc143.targets" Condition="Exists('..\packages\boost_regex-vc143.1.86.0\build\boost_regex-vc143.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="..\packages\Microsoft.Web.WebView2.1.0.2651.64\build\native\Microsoft.Web.WebView2.targets" Condition="Exists('..\packages\Microsoft.Web.WebView2.1.0.2651.64\build\native\Microsoft.Web.WebView2.targets')" />
+    <Import Project="..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.targets" Condition="Exists('..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -392,12 +408,13 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.240405.15\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\boost.1.85.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.85.0\build\boost.targets'))" />
-    <Error Condition="!Exists('..\packages\boost_regex-vc143.1.85.0\build\boost_regex-vc143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost_regex-vc143.1.85.0\build\boost_regex-vc143.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240122.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1\build\Microsoft.Windows.SDK.BuildTools.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1\build\Microsoft.Windows.SDK.BuildTools.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1\build\Microsoft.Windows.SDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.SDK.BuildTools.10.0.26100.1\build\Microsoft.Windows.SDK.BuildTools.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.WindowsAppSDK.1.5.240627000\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WindowsAppSDK.1.5.240627000\build\native\Microsoft.WindowsAppSDK.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.WindowsAppSDK.1.5.240627000\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WindowsAppSDK.1.5.240627000\build\native\Microsoft.WindowsAppSDK.targets'))" />
+    <Error Condition="!Exists('..\packages\boost.1.86.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.86.0\build\boost.targets'))" />
+    <Error Condition="!Exists('..\packages\boost_regex-vc143.1.86.0\build\boost_regex-vc143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost_regex-vc143.1.86.0\build\boost_regex-vc143.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.ImplementationLibrary.1.0.240803.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Web.WebView2.1.0.2651.64\build\native\Microsoft.Web.WebView2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Web.WebView2.1.0.2651.64\build\native\Microsoft.Web.WebView2.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.WindowsAppSDK.1.6.240829007\build\native\Microsoft.WindowsAppSDK.targets'))" />
   </Target>
 </Project>

--- a/ClipboardManager/MainPage.h
+++ b/ClipboardManager/MainPage.h
@@ -59,10 +59,9 @@ namespace winrt::ClipboardManager::implementation
         clip::notifs::ToastNotificationHandler& manager = clip::notifs::ToastNotificationHandler::getDefault();
         clip::HotKey activationHotKey{ MOD_ALT, L' ' };
         std::vector<clip::ClipboardTrigger> triggers{};
-        winrt::Windows::ApplicationModel::DataTransfer::Clipboard::ContentChanged_revoker clipboardContentChangedrevoker{};
-        winrt::Windows::Foundation::Collections::IObservableVector<winrt::ClipboardManager::ClipboardActionView> clipboardActionViews
-            = winrt::single_threaded_observable_vector<winrt::ClipboardManager::ClipboardActionView>();
+        winrt::Windows::Foundation::Collections::IObservableVector<winrt::ClipboardManager::ClipboardActionView> clipboardActionViews = winrt::single_threaded_observable_vector<winrt::ClipboardManager::ClipboardActionView>();
         size_t teachingTipIndex = 0;
+        winrt::event_token clipboardContentChangedToken{};
 
         winrt::async ClipboardContent_Changed(const winrt::Windows::Foundation::IInspectable& sender, const winrt::Windows::Foundation::IInspectable& args);
         void Editor_FormatChanged(const winrt::ClipboardManager::ClipboardActionEditor& sender, const winrt::hstring& oldFormat);

--- a/ClipboardManager/MainPage.h
+++ b/ClipboardManager/MainPage.h
@@ -7,6 +7,8 @@
 #include "src/ui/VisualStateManager.hpp"
 #include "src/notifs/ToastNotificationHandler.hpp"
 
+#include <winrt/Windows.Media.Ocr.h>
+#include <winrt/Windows.Storage.Streams.h>
 
 #include <vector>
 #include <filesystem>
@@ -75,7 +77,9 @@ namespace winrt::ClipboardManager::implementation
         void ReloadTriggers();
         bool LoadTriggers(std::filesystem::path& path);
         void LaunchAction(const std::wstring& url);
-        winrt::async loadClipboardHistory();
+        winrt::async LoadClipboardHistory();
+        Windows::Foundation::IAsyncOperation<Windows::Media::Ocr::OcrResult> RunOcr(Windows::Storage::Streams::IRandomAccessStreamWithContentType& bitmapStream);
+        winrt::async AddClipboardItem(Windows::ApplicationModel::DataTransfer::DataPackageView& content, const bool& runTriggers);
     };
 }
 

--- a/ClipboardManager/MainPage.xaml
+++ b/ClipboardManager/MainPage.xaml
@@ -103,44 +103,7 @@
                     <FontIcon x:Name="ClipboardHistoryPivot" Glyph="&#xe823;" FontSize="16"/>
                 </PivotItem.Header>
 
-                <ListView x:Name="ClipboardHistoryListView" SelectionMode="None" Grid.Row="1">
-                    <ListView.ItemTemplate>
-                        <DataTemplate>
-                            <Grid Background="{ThemeResource SolidBackgroundFillColorTertiaryBrush}" CornerRadius="{StaticResource OverlayCornerRadius}" BorderBrush="{ThemeResource ExpanderHeaderBorderBrush}" BorderThickness="1" Padding="7,5" Margin="0,3,0,3">
-                                <Grid.Transitions>
-                                    <TransitionCollection>
-                                        <RepositionThemeTransition/>
-                                    </TransitionCollection>
-                                </Grid.Transitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="1*"/>
-                                    <RowDefinition Height="1*"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
-                                <Grid.Resources>
-                                    <Style TargetType="TextBlock">
-                                        <Setter Property="IsTextSelectionEnabled" Value="True"/>
-                                    </Style>
-                                </Grid.Resources>
-
-                                <ContentPresenter Content="{x:Bind}" Grid.Column="0" MaxHeight="60" TextWrapping="Wrap"/>
-
-                                <StackPanel Grid.Column="1" Grid.RowSpan="2" Orientation="Vertical" Spacing="5">
-                                    <Button Style="{StaticResource IconButtonStyle}">
-                                        <FontIcon Glyph="&#xe8c8;" FontSize="14"/>
-                                    </Button>
-                                    <Button Style="{StaticResource IconButtonStyle}">
-                                        <FontIcon Glyph="&#xe718;" FontSize="14"/>
-                                    </Button>
-                                </StackPanel>
-                            </Grid>
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
+                <ListView x:Name="ClipboardHistoryListView" SelectionMode="None" Grid.Row="0"/>
             </PivotItem>
 
             <PivotItem Padding="0" Margin="0" Loaded="ClipboadTriggersListPivot_Loaded">

--- a/ClipboardManager/MainPage.xaml
+++ b/ClipboardManager/MainPage.xaml
@@ -104,7 +104,7 @@
 
                 <ListView x:Name="ClipboardHistoryListView" SelectionMode="None" Grid.Row="1">
                     <ListView.ItemTemplate>
-                        <DataTemplate x:DataType="x:String">
+                        <DataTemplate>
                             <Grid Background="{ThemeResource SolidBackgroundFillColorTertiaryBrush}" CornerRadius="{StaticResource OverlayCornerRadius}" BorderBrush="{ThemeResource ExpanderHeaderBorderBrush}" BorderThickness="1" Padding="7,5" Margin="0,3,0,3">
                                 <Grid.Transitions>
                                     <TransitionCollection>
@@ -120,8 +120,13 @@
                                     <RowDefinition Height="1*"/>
                                     <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
+                                <Grid.Resources>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="IsTextSelectionEnabled" Value="True"/>
+                                    </Style>
+                                </Grid.Resources>
 
-                                <TextBlock Text="{x:Bind}" IsTextSelectionEnabled="True" Grid.Column="0" MaxHeight="60" TextWrapping="Wrap"/>
+                                <ContentPresenter Content="{x:Bind}" Grid.Column="0" MaxHeight="60" TextWrapping="Wrap"/>
 
                                 <StackPanel Grid.Column="1" Grid.RowSpan="2" Orientation="Vertical" Spacing="5">
                                     <Button Style="{StaticResource IconButtonStyle}">

--- a/ClipboardManager/MessagesBar.cpp
+++ b/ClipboardManager/MessagesBar.cpp
@@ -13,7 +13,7 @@ namespace winrt::ClipboardManager::implementation
 {
     void MessagesBar::Add(const winrt::hstring& title, const winrt::hstring& message, const xaml::InfoBarSeverity& severity)
     {
-        infoBars.push_back(CreateInfoBar(title, message));
+        infoBars.push_back(CreateInfoBar(title, message, severity));
 
         InfoBadge().Value(static_cast<int32_t>(infoBars.size()));
         PipsPager().NumberOfPages(static_cast<int32_t>(infoBars.size()));
@@ -59,7 +59,7 @@ namespace winrt::ClipboardManager::implementation
 
     void MessagesBar::AddContent(const winrt::hstring& titleContent, const winrt::hstring& messageContent, const winrt::Windows::Foundation::IInspectable& content, const winrt::Microsoft::UI::Xaml::Controls::InfoBarSeverity& severity)
     {
-        auto&& infoBar = CreateInfoBar(titleContent, messageContent);
+        auto&& infoBar = CreateInfoBar(titleContent, messageContent, severity);
         infoBar.Content(content);
         infoBar.Severity(severity);
 
@@ -133,7 +133,8 @@ namespace winrt::ClipboardManager::implementation
         }
     }
 
-    Microsoft::UI::Xaml::Controls::InfoBar MessagesBar::CreateInfoBar(const winrt::hstring& title, const winrt::hstring& message, const Windows::Foundation::IInspectable& content)
+    Microsoft::UI::Xaml::Controls::InfoBar MessagesBar::CreateInfoBar(
+        const winrt::hstring& title, const winrt::hstring& message, const winrt::Microsoft::UI::Xaml::Controls::InfoBarSeverity& severity, const Windows::Foundation::IInspectable& content)
     {
         Microsoft::UI::Xaml::Controls::InfoBar infoBar{};
 
@@ -152,7 +153,7 @@ namespace winrt::ClipboardManager::implementation
             infoBar.Content(content);
         }
 
-        infoBar.Severity(Microsoft::UI::Xaml::Controls::InfoBarSeverity::Error);
+        infoBar.Severity(severity);
         infoBar.IsOpen(true);
 
         infoBar.Closed([this](auto&& infoBar, auto&&)

--- a/ClipboardManager/MessagesBar.h
+++ b/ClipboardManager/MessagesBar.h
@@ -43,7 +43,11 @@ namespace winrt::ClipboardManager::implementation
         void LoadFirst();
         void LoadNext();
         void LoadPrevious();
-        Microsoft::UI::Xaml::Controls::InfoBar CreateInfoBar(const winrt::hstring& title, const winrt::hstring& message, const Windows::Foundation::IInspectable& content = nullptr);
+        Microsoft::UI::Xaml::Controls::InfoBar CreateInfoBar(
+            const winrt::hstring& title, 
+            const winrt::hstring& message, 
+            const winrt::Microsoft::UI::Xaml::Controls::InfoBarSeverity& severity,
+            const Windows::Foundation::IInspectable& content = nullptr);
     };
 }
 

--- a/ClipboardManager/Resource.h
+++ b/ClipboardManager/Resource.h
@@ -14,7 +14,7 @@
 #define IDR_MAINFRAME                   128
 #define IDC_STATIC                      -1
 
-#define APP_VERSION                     L"0.4.0"
+#define APP_VERSION                     L"0.4.2"
 
 // Next default values for new objects
 // 

--- a/ClipboardManager/Resources.lang-fr-fr.resw
+++ b/ClipboardManager/Resources.lang-fr-fr.resw
@@ -178,7 +178,7 @@
     <comment>SettingsPage</comment>
   </data>
   <data name="BrowserStringTextBox.PlaceholderText" xml:space="preserve">
-    <value>Chaine executable</value>
+    <value>Chaine exécutable</value>
     <comment>SettingsPage</comment>
   </data>
   <data name="ClearActionsButtonToolTipTextBlock.Text" xml:space="preserve">
@@ -190,7 +190,7 @@
     <comment>SettingsPage</comment>
   </data>
   <data name="ClearSettingsHostControl.Header" xml:space="preserve">
-    <value>Nettoyer les parmètres</value>
+    <value>Nettoyer les paramètres</value>
     <comment>SettingsPage</comment>
   </data>
   <data name="ClipboardActionRootGridTeachingTip.Subtitle" xml:space="preserve">

--- a/ClipboardManager/SettingsPage.cpp
+++ b/ClipboardManager/SettingsPage.cpp
@@ -18,7 +18,6 @@
 
 #include <Shobjidl.h>
 
-namespace implementation = winrt::ClipboardManager::implementation;
 namespace winrt
 {
     using namespace winrt::Windows::Foundation;
@@ -32,222 +31,233 @@ namespace xaml
     using namespace winrt::Microsoft::UI::Xaml::Controls::Primitives;
 }
 
-void implementation::SettingsPage::Page_Loading(winrt::FrameworkElement const&, winrt::IInspectable const&)
+namespace winrt::ClipboardManager::implementation
 {
-    ApplicationVersionHostControl().HostContent(box_value(APP_VERSION));
-
-    clip::utils::StartupTask startupTask{};
-    AutoStartToggleSwitch().IsOn(startupTask.isTaskRegistered());
-
-    SaveMatchingResultsToggleSwitch().IsOn(settings.get<bool>(L"SaveMatchingResults").value_or(false));
-    StartMinimizedToggleSwitch().IsOn(settings.get<bool>(L"StartWindowMinimized").value_or(false));
-    NotificationsToggleSwitch().IsOn(settings.get<bool>(L"NotificationsEnabled").value_or(true));
-    
-    auto durationType = settings.get<clip::notifs::NotificationDurationType>(L"NotificationDurationType").value_or(clip::notifs::NotificationDurationType::Default);
-    DurationDefaultToggleButton().IsChecked(durationType == clip::notifs::NotificationDurationType::Default);
-    DurationShortToggleButton().IsChecked(durationType == clip::notifs::NotificationDurationType::Short);
-    DurationLongToggleButton().IsChecked(durationType == clip::notifs::NotificationDurationType::Long);
-
-    auto scenarioType = settings.get<clip::notifs::NotificationScenarioType>(L"NotificationScenarioType").value_or(clip::notifs::NotificationScenarioType::Default);
-    auto soundType = settings.get<clip::notifs::NotificationSoundType>(L"NotificationSoundType").value_or(clip::notifs::NotificationSoundType::Default);
-    selectComboBoxItem(NotificationScenariosComboBox(), (int32_t)scenarioType);
-    selectComboBoxItem(NotificationSoundComboBox(), (int32_t)soundType);
-
-    BrowserStringTextBox().Text(settings.get<std::wstring>(L"CustomProcessString").value_or(L""));
-    UseCustomBrowser().IsOn(settings.get<bool>(L"UseCustomProcess").value_or(false));
-
-    AllowMaximizeToggleSwitch().IsOn(settings.get<bool>(L"AllowWindowMaximize").value_or(false));
-    AllowMinimizeToggleSwitch().IsOn(settings.get<bool>(L"AllowWindowMinimize").value_or(true));
-}
-
-void implementation::SettingsPage::Page_Loaded(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
-{
-    loaded = true;
-}
-
-void implementation::SettingsPage::AutoStartToggleSwitch_Toggled(winrt::IInspectable const& s, winrt::RoutedEventArgs const&)
-{
-    check_loaded(loaded);
-    auto sender = s.as<xaml::ToggleSwitch>();
-
-    clip::utils::StartupTask startupTask{};
-    if (!startupTask.isTaskRegistered() && sender.IsOn())
+    void SettingsPage::Page_Loading(winrt::FrameworkElement const&, winrt::IInspectable const&)
     {
-        startupTask.set();
+        ApplicationVersionHostControl().HostContent(box_value(APP_VERSION));
+
+        clip::utils::StartupTask startupTask{};
+        AutoStartToggleSwitch().IsOn(startupTask.isTaskRegistered());
+
+        SaveMatchingResultsToggleSwitch().IsOn(settings.get<bool>(L"SaveMatchingResults").value_or(false));
+        StartMinimizedToggleSwitch().IsOn(settings.get<bool>(L"StartWindowMinimized").value_or(false));
+        NotificationsToggleSwitch().IsOn(settings.get<bool>(L"NotificationsEnabled").value_or(true));
+
+        AddDuplicatedActionsToggleSwitch().IsOn(settings.get<bool>(L"AddDuplicatedActions").value_or(true));
+
+        auto durationType = settings.get<clip::notifs::NotificationDurationType>(L"NotificationDurationType").value_or(clip::notifs::NotificationDurationType::Default);
+        DurationDefaultToggleButton().IsChecked(durationType == clip::notifs::NotificationDurationType::Default);
+        DurationShortToggleButton().IsChecked(durationType == clip::notifs::NotificationDurationType::Short);
+        DurationLongToggleButton().IsChecked(durationType == clip::notifs::NotificationDurationType::Long);
+
+        auto scenarioType = settings.get<clip::notifs::NotificationScenarioType>(L"NotificationScenarioType").value_or(clip::notifs::NotificationScenarioType::Default);
+        auto soundType = settings.get<clip::notifs::NotificationSoundType>(L"NotificationSoundType").value_or(clip::notifs::NotificationSoundType::Default);
+        selectComboBoxItem(NotificationScenariosComboBox(), (int32_t)scenarioType);
+        selectComboBoxItem(NotificationSoundComboBox(), (int32_t)soundType);
+
+        BrowserStringTextBox().Text(settings.get<std::wstring>(L"CustomProcessString").value_or(L""));
+        UseCustomBrowser().IsOn(settings.get<bool>(L"UseCustomProcess").value_or(false));
+
+        AllowMaximizeToggleSwitch().IsOn(settings.get<bool>(L"AllowWindowMaximize").value_or(false));
+        AllowMinimizeToggleSwitch().IsOn(settings.get<bool>(L"AllowWindowMinimize").value_or(true));
     }
-    else if (startupTask.isTaskRegistered() && !sender.IsOn())
+
+    void SettingsPage::Page_Loaded(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
     {
-        startupTask.remove();
+        loaded = true;
     }
-}
 
-void implementation::SettingsPage::StartMinimizedToggleSwitch_Toggled(winrt::IInspectable const& s, xaml::RoutedEventArgs const&)
-{
-    check_loaded(loaded);
-    updateSetting(s, L"StartWindowMinimized");
-}
-
-void implementation::SettingsPage::SaveMatchingResultsToggleSwitch_Toggled(winrt::IInspectable const& s, xaml::RoutedEventArgs const&)
-{
-    check_loaded(loaded);
-    updateSetting(s, L"SaveMatchingResults");
-}
-
-void implementation::SettingsPage::EnableListeningToggleSwitch_Toggled(winrt::IInspectable const& s, xaml::RoutedEventArgs const&)
-{
-    NotificationsExpander().IsEnabled(NotificationsToggleSwitch().IsOn());
-    
-    check_loaded(loaded);
-    updateSetting(s, L"NotificationsEnabled");
-}
-
-void implementation::SettingsPage::DurationToggleButton_Click(winrt::IInspectable const& sender, xaml::RoutedEventArgs const& e)
-{
-    auto senderToggleButton = sender.as<xaml::ToggleButton>();
-    if (senderToggleButton.IsChecked())
+    void SettingsPage::AutoStartToggleSwitch_Toggled(winrt::IInspectable const& s, winrt::RoutedEventArgs const&)
     {
-        for (auto&& child : DurationButtonsStackPanel().Children())
+        check_loaded(loaded);
+        auto sender = s.as<xaml::ToggleSwitch>();
+
+        clip::utils::StartupTask startupTask{};
+        if (!startupTask.isTaskRegistered() && sender.IsOn())
         {
-            auto toggleButton = child.as<xaml::ToggleButton>();
-            if (toggleButton.Tag().as<hstring>() != senderToggleButton.Tag().as<hstring>())
+            startupTask.set();
+        }
+        else if (startupTask.isTaskRegistered() && !sender.IsOn())
+        {
+            startupTask.remove();
+        }
+    }
+
+    void SettingsPage::StartMinimizedToggleSwitch_Toggled(winrt::IInspectable const& s, xaml::RoutedEventArgs const&)
+    {
+        check_loaded(loaded);
+        updateSetting(s, L"StartWindowMinimized");
+    }
+
+    void SettingsPage::SaveMatchingResultsToggleSwitch_Toggled(winrt::IInspectable const& s, xaml::RoutedEventArgs const&)
+    {
+        check_loaded(loaded);
+        updateSetting(s, L"SaveMatchingResults");
+    }
+
+    void SettingsPage::EnableListeningToggleSwitch_Toggled(winrt::IInspectable const& s, xaml::RoutedEventArgs const&)
+    {
+        NotificationsExpander().IsEnabled(NotificationsToggleSwitch().IsOn());
+
+        check_loaded(loaded);
+        updateSetting(s, L"NotificationsEnabled");
+    }
+
+    void SettingsPage::DurationToggleButton_Click(winrt::IInspectable const& sender, xaml::RoutedEventArgs const& e)
+    {
+        auto senderToggleButton = sender.as<xaml::ToggleButton>();
+        if (senderToggleButton.IsChecked())
+        {
+            for (auto&& child : DurationButtonsStackPanel().Children())
             {
-                toggleButton.IsChecked(false);
+                auto toggleButton = child.as<xaml::ToggleButton>();
+                if (toggleButton.Tag().as<hstring>() != senderToggleButton.Tag().as<hstring>())
+                {
+                    toggleButton.IsChecked(false);
+                }
+            }
+        }
+
+        auto tag = std::stoi(std::wstring(senderToggleButton.Tag().as<hstring>()));
+        settings.insert(L"NotificationDurationType", static_cast<clip::notifs::NotificationDurationType>(tag));
+    }
+
+    void SettingsPage::NotificationScenariosComboBox_SelectionChanged(winrt::IInspectable const&, xaml::SelectionChangedEventArgs const& e)
+    {
+        check_loaded(loaded);
+        settings.insert(L"NotificationScenarioType", getSelectedComboBoxItemTag(NotificationScenariosComboBox()));
+    }
+
+    void SettingsPage::NotificationSoundComboBox_SelectionChanged(winrt::IInspectable const&, xaml::SelectionChangedEventArgs const& e)
+    {
+        check_loaded(loaded);
+        settings.insert(L"NotificationSoundType", getSelectedComboBoxItemTag(NotificationSoundComboBox()));
+    }
+
+    void SettingsPage::IgnoreCaseToggleSwitch_Toggled(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
+    {
+        check_loaded(loaded);
+        settings.insert(L"RegexIgnoreCase", IgnoreCaseToggleSwitch().IsOn());
+    }
+
+    void SettingsPage::RegexModeComboBox_SelectionChanged(winrt::IInspectable const&, xaml::SelectionChangedEventArgs const&)
+    {
+        check_loaded(loaded);
+        settings.insert(L"TriggerMatchMode", RegexModeComboBox().SelectedItem().as<winrt::FrameworkElement>().Tag().as<int32_t>());
+    }
+
+    winrt::async SettingsPage::CreateExampleTriggersFileButton_Click(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
+    {
+        winrt::FileSavePicker picker{};
+        picker.as<IInitializeWithWindow>()->Initialize(GetActiveWindow());
+        picker.SuggestedStartLocation(winrt::PickerLocationId::ComputerFolder);
+        picker.SuggestedFileName(L"user_file.xml");
+        picker.FileTypeChoices().Insert(
+            L"XML Files", single_threaded_vector<winrt::hstring>({ L".xml" })
+        );
+
+        auto&& storageFile = co_await picker.PickSaveFileAsync();
+        if (storageFile)
+        {
+            std::filesystem::path userFilePath{ storageFile.Path().c_str() };
+            clip::ClipboardTrigger::initializeSaveFile(userFilePath);
+        }
+    }
+
+    winrt::async SettingsPage::OverwriteExampleTriggersFileButton_Click(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
+    {
+        winrt::FileOpenPicker picker{};
+        picker.as<IInitializeWithWindow>()->Initialize(GetActiveWindow());
+        picker.FileTypeFilter().Append(L".xml");
+
+        auto&& storageFile = co_await picker.PickSingleFileAsync();
+        if (storageFile)
+        {
+            std::filesystem::path userFilePath{ storageFile.Path().c_str() };
+            settings.insert(L"UserFilePath", userFilePath);
+            clip::ClipboardTrigger::initializeSaveFile(userFilePath);
+        }
+    }
+
+    void SettingsPage::SaveBrowserStringButton_Click(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
+    {
+        BrowserStringTextBox_TextChanged(nullptr, nullptr);
+    }
+
+    void SettingsPage::BrowserStringTextBox_TextChanged(winrt::IInspectable const&, xaml::TextChangedEventArgs const&)
+    {
+        check_loaded(loaded);
+        // TODO: Check if writing that fast to the registry can hurt performance.
+        settings.insert(L"CustomProcessString", BrowserStringTextBox().Text());
+    }
+
+    void SettingsPage::UseCustomBrowser_Toggled(winrt::IInspectable const& sender, winrt::RoutedEventArgs const&)
+    {
+        check_loaded(loaded);
+        updateSetting(sender, L"UseCustomProcess");
+    }
+
+    void SettingsPage::HideAppWindowToggleSwitch_Toggled(winrt::IInspectable const& sender, winrt::RoutedEventArgs const&)
+    {
+        check_loaded(loaded);
+        updateSetting(sender, L"HideAppWindow");
+    }
+
+    void SettingsPage::ClearSettingsButton_Click(winrt::IInspectable const&, xaml::RoutedEventArgs const& e)
+    {
+        settings.clear();
+        visualStateManager.goToState(ClearSettingsShowIconState);
+    }
+
+    void SettingsPage::TriggersStorageExpander_Expanding(xaml::Controls::Expander const&, xaml::Controls::ExpanderExpandingEventArgs const&)
+    {
+        UserFilePathTextBlock().Text(settings.get<hstring>(L"UserFilePath").value_or(L""));
+    }
+
+    winrt::async SettingsPage::LocateButton_Clicked(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e)
+    {
+        FileOpenPicker picker{};
+        picker.as<IInitializeWithWindow>()->Initialize(GetActiveWindow());
+        picker.FileTypeFilter().Append(L".xml");
+
+        auto&& storageFile = co_await picker.PickSingleFileAsync();
+        if (storageFile)
+        {
+            std::filesystem::path userFilePath{ storageFile.Path().c_str() };
+            settings.insert(L"UserFilePath", userFilePath);
+        }
+    }
+
+    void SettingsPage::AddDuplicatedActionsToggleSwitch_Toggled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e)
+    {
+        check_loaded(loaded);
+        updateSetting(sender, L"AddDuplicatedActions");
+    }
+
+
+    void SettingsPage::updateSetting(winrt::Windows::Foundation::IInspectable const& s, const std::wstring& key)
+    {
+        auto sender = s.as<xaml::ToggleSwitch>();
+        auto isOn = sender.IsOn();
+        settings.insert(key, isOn);
+    }
+
+    void SettingsPage::selectComboBoxItem(const winrt::Microsoft::UI::Xaml::Controls::ComboBox& comboBox, const uint32_t& value)
+    {
+        for (auto&& inspectable : comboBox.Items())
+        {
+            auto item = inspectable.try_as<xaml::ComboBoxItem>();
+            if (item && item.Tag().as<hstring>() == std::to_wstring(value))
+            {
+                comboBox.SelectedItem(inspectable);
+                break;
             }
         }
     }
 
-    auto tag = std::stoi(std::wstring(senderToggleButton.Tag().as<hstring>()));
-    settings.insert(L"NotificationDurationType", static_cast<clip::notifs::NotificationDurationType>(tag));
-}
-
-void implementation::SettingsPage::NotificationScenariosComboBox_SelectionChanged(winrt::IInspectable const&, xaml::SelectionChangedEventArgs const& e)
-{
-    check_loaded(loaded);
-    settings.insert(L"NotificationScenarioType", getSelectedComboBoxItemTag(NotificationScenariosComboBox()));
-}
-
-void implementation::SettingsPage::NotificationSoundComboBox_SelectionChanged(winrt::IInspectable const&, xaml::SelectionChangedEventArgs const& e)
-{
-    check_loaded(loaded);
-    settings.insert(L"NotificationSoundType", getSelectedComboBoxItemTag(NotificationSoundComboBox()));
-}
-
-void implementation::SettingsPage::IgnoreCaseToggleSwitch_Toggled(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
-{
-    check_loaded(loaded);
-    settings.insert(L"RegexIgnoreCase", IgnoreCaseToggleSwitch().IsOn());
-}
-
-void implementation::SettingsPage::RegexModeComboBox_SelectionChanged(winrt::IInspectable const&, xaml::SelectionChangedEventArgs const&)
-{
-    check_loaded(loaded);
-    settings.insert(L"TriggerMatchMode", RegexModeComboBox().SelectedItem().as<winrt::FrameworkElement>().Tag().as<int32_t>());
-}
-
-winrt::async implementation::SettingsPage::CreateExampleTriggersFileButton_Click(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
-{
-    winrt::FileSavePicker picker{};
-    picker.as<IInitializeWithWindow>()->Initialize(GetActiveWindow());
-    picker.SuggestedStartLocation(winrt::PickerLocationId::ComputerFolder);
-    picker.SuggestedFileName(L"user_file.xml");
-    picker.FileTypeChoices().Insert(
-        L"XML Files", single_threaded_vector<winrt::hstring>({ L".xml" })
-    );
-
-    auto&& storageFile = co_await picker.PickSaveFileAsync();
-    if (storageFile)
+    uint32_t SettingsPage::getSelectedComboBoxItemTag(const winrt::Microsoft::UI::Xaml::Controls::ComboBox& comboBox)
     {
-        std::filesystem::path userFilePath{ storageFile.Path().c_str() };
-        clip::ClipboardTrigger::initializeSaveFile(userFilePath);
+        return std::stoi(comboBox.SelectedItem().as<xaml::ComboBoxItem>().Tag().as<hstring>().data());
     }
-}
-
-winrt::async implementation::SettingsPage::OverwriteExampleTriggersFileButton_Click(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
-{
-    winrt::FileOpenPicker picker{};
-    picker.as<IInitializeWithWindow>()->Initialize(GetActiveWindow());
-    picker.FileTypeFilter().Append(L".xml");
-
-    auto&& storageFile = co_await picker.PickSingleFileAsync();
-    if (storageFile)
-    {
-        std::filesystem::path userFilePath{ storageFile.Path().c_str() };
-        settings.insert(L"UserFilePath", userFilePath);
-        clip::ClipboardTrigger::initializeSaveFile(userFilePath);
-    }
-}
-
-void implementation::SettingsPage::SaveBrowserStringButton_Click(winrt::IInspectable const&, winrt::RoutedEventArgs const&)
-{
-    BrowserStringTextBox_TextChanged(nullptr, nullptr);
-}
-
-void implementation::SettingsPage::BrowserStringTextBox_TextChanged(winrt::IInspectable const&, xaml::TextChangedEventArgs const&)
-{
-    check_loaded(loaded);
-    // TODO: Check if writing that fast to the registry can hurt performance.
-    settings.insert(L"CustomProcessString", BrowserStringTextBox().Text());
-}
-
-void implementation::SettingsPage::UseCustomBrowser_Toggled(winrt::IInspectable const& sender, winrt::RoutedEventArgs const&)
-{
-    check_loaded(loaded);
-    updateSetting(sender, L"UseCustomProcess");
-}
-
-void implementation::SettingsPage::HideAppWindowToggleSwitch_Toggled(winrt::IInspectable const& sender, winrt::RoutedEventArgs const&)
-{
-    check_loaded(loaded);
-    updateSetting(sender, L"HideAppWindow");
-}
-
-void implementation::SettingsPage::ClearSettingsButton_Click(winrt::IInspectable const&, xaml::RoutedEventArgs const& e)
-{
-    settings.clear();
-    visualStateManager.goToState(ClearSettingsShowIconState);
-}
-
-void implementation::SettingsPage::TriggersStorageExpander_Expanding(xaml::Controls::Expander const&, xaml::Controls::ExpanderExpandingEventArgs const&)
-{
-    UserFilePathTextBlock().Text(settings.get<hstring>(L"UserFilePath").value_or(L""));
-}
-
-winrt::async implementation::SettingsPage::LocateButton_Clicked(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e)
-{
-    FileOpenPicker picker{};
-    picker.as<IInitializeWithWindow>()->Initialize(GetActiveWindow());
-    picker.FileTypeFilter().Append(L".xml");
-
-    auto&& storageFile = co_await picker.PickSingleFileAsync();
-    if (storageFile)
-    {
-        std::filesystem::path userFilePath{ storageFile.Path().c_str() };
-        settings.insert(L"UserFilePath", userFilePath);
-    }
-}
-
-
-void implementation::SettingsPage::updateSetting(winrt::Windows::Foundation::IInspectable const& s, const std::wstring& key)
-{
-    auto sender = s.as<xaml::ToggleSwitch>();
-    auto isOn = sender.IsOn();
-    settings.insert(key, isOn);
-}
-
-void implementation::SettingsPage::selectComboBoxItem(const winrt::Microsoft::UI::Xaml::Controls::ComboBox& comboBox, const uint32_t& value)
-{
-    for (auto&& inspectable : comboBox.Items())
-    {
-        auto item = inspectable.try_as<xaml::ComboBoxItem>();
-        if (item && item.Tag().as<hstring>() == std::to_wstring(value))
-        {
-            comboBox.SelectedItem(inspectable);
-            break;
-        }
-    }
-}
-
-uint32_t implementation::SettingsPage::getSelectedComboBoxItemTag(const winrt::Microsoft::UI::Xaml::Controls::ComboBox& comboBox)
-{
-    return std::stoi(comboBox.SelectedItem().as<xaml::ComboBoxItem>().Tag().as<hstring>().data());
 }

--- a/ClipboardManager/SettingsPage.h
+++ b/ClipboardManager/SettingsPage.h
@@ -45,6 +45,8 @@ namespace winrt::ClipboardManager::implementation
         void updateSetting(winrt::Windows::Foundation::IInspectable const& s, const std::wstring& key);
         void selectComboBoxItem(const winrt::Microsoft::UI::Xaml::Controls::ComboBox& comboBox, const uint32_t& value);
         uint32_t getSelectedComboBoxItemTag(const winrt::Microsoft::UI::Xaml::Controls::ComboBox& comboBox);
+    public:
+        void AddDuplicatedActionsToggleSwitch_Toggled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
     };
 }
 

--- a/ClipboardManager/SettingsPage.xaml
+++ b/ClipboardManager/SettingsPage.xaml
@@ -203,7 +203,7 @@
 
             <clip:HostControl x:Uid="AddDuplicatedActionsHostControl">
                 <clip:HostControl.HostContent>
-                    <ToggleSwitch/>
+                    <ToggleSwitch x:Name="AddDuplicatedActionsToggleSwitch" Toggled="AddDuplicatedActionsToggleSwitch_Toggled"/>
                 </clip:HostControl.HostContent>
             </clip:HostControl>
             <!--#endregion-->

--- a/ClipboardManager/packages.config
+++ b/ClipboardManager/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="boost" version="1.85.0" targetFramework="native" />
-  <package id="boost_regex-vc143" version="1.85.0" targetFramework="native" />
+  <package id="boost" version="1.86.0" targetFramework="native" />
+  <package id="boost_regex-vc143" version="1.86.0" targetFramework="native" />
+  <package id="Microsoft.Web.WebView2" version="1.0.2651.64" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.240405.15" targetFramework="native" />
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240122.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.240803.1" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.BuildTools" version="10.0.26100.1" targetFramework="native" />
-  <package id="Microsoft.WindowsAppSDK" version="1.5.240627000" targetFramework="native" />
+  <package id="Microsoft.WindowsAppSDK" version="1.6.240829007" targetFramework="native" />
 </packages>

--- a/ClipboardManager/src/Settings.hpp
+++ b/ClipboardManager/src/Settings.hpp
@@ -13,6 +13,7 @@
 #include <concepts>
 #include <iostream>
 
+//#define ENABLE_LOGGING
 
 namespace clip
 {
@@ -80,7 +81,10 @@ namespace clip
         Settings()
         {
             hKey = wil::reg::create_unique_key(HKEY_CURRENT_USER, (L"SOFTWARE\\" + applicationName).c_str(), wil::reg::key_access::readwrite);
+#ifdef ENABLE_LOGGING
             logger.debug(L"Opened registry node for application settings.");
+#endif // ENABLE_LOGGING
+
         }
 
         std::vector<std::pair<std::wstring, clip::reg_types>> getAll();
@@ -103,7 +107,7 @@ namespace clip
         template<concepts::LongIntegralInsertable T>
         std::optional<T> get(const key_t& key);
 
-        template<concepts::EnumInsertable T> 
+        template<concepts::EnumInsertable T>
         std::optional<T> get(const key_t& key);
 
         template<concepts::Insertable T>
@@ -127,7 +131,10 @@ namespace clip
     private:
         const std::wstring applicationName = L"ClipboardManagerV2";
         wil::unique_hkey hKey{ nullptr };
+#ifdef ENABLE_LOGGING
         utils::Logger logger{ L"Settings" };
+#endif // ENABLE_LOGGING
+
 
         void clearKey(HKEY hkey);
         wil::shared_hkey createSubKey(const key_t& key);

--- a/ClipboardManager/src/implementation/Settings_implementation.hpp
+++ b/ClipboardManager/src/implementation/Settings_implementation.hpp
@@ -5,9 +5,11 @@ namespace clip
     {
         std::vector<std::pair<std::wstring, reg_types>> entries{};
 
+#ifdef ENABLE_LOGGING
         logger.info(std::format(L"Retreiving all settings. {} values, {} subkeys.", 
             wil::reg::get_child_value_count(hKey.get()),
             wil::reg::get_child_key_count(hKey.get())));
+#endif
 
         // Iterate sub keys.
         {
@@ -100,7 +102,10 @@ namespace clip
         }
         else
         {
+#ifdef ENABLE_LOGGING
             logger.debug(L"'" + key + L"' not in registry.");
+#endif // ENABLE_LOGGING
+
             return std::optional<bool>();
         }
     }
@@ -252,7 +257,10 @@ namespace clip
                 clearKey(subKey.get());
             }
 
+#ifdef ENABLE_LOGGING
             logger.error(ex.what());
+#endif // ENABLE_LOGGING
+
             throw;
         }
     }

--- a/ClipboardManager/src/utils/com_closable_ptr.h
+++ b/ClipboardManager/src/utils/com_closable_ptr.h
@@ -11,12 +11,12 @@ namespace clip::utils
         source->Close();
     }*/
     
-    inline void __stdcall closeIClosable(winrt::Windows::Foundation::IClosable source)
+    inline void __stdcall closeIClosable(winrt::Windows::Foundation::IClosable* source)
     {
-        source.Close();
+        source->Close();
     }
 
-    using unique_closable = std::unique_ptr<winrt::Windows::Foundation::IClosable, std::function<void(winrt::Windows::Foundation::IClosable)>>;
+    using unique_closable = std::unique_ptr<winrt::Windows::Foundation::IClosable, std::function<void(winrt::Windows::Foundation::IClosable*)>>;
     
     /*using unique_closable_call = 
         wil::unique_com_call<

--- a/ClipboardManager/src/utils/com_closable_ptr.h
+++ b/ClipboardManager/src/utils/com_closable_ptr.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <winrt/Windows.Foundation.h>
+#include <wil/com.h>
+#include <memory>
+#include <functional>
+
+namespace clip::utils
+{
+    /*inline void __stdcall closeIClosable(winrt::Windows::Foundation::IClosable* source)
+    {
+        source->Close();
+    }*/
+    
+    inline void __stdcall closeIClosable(winrt::Windows::Foundation::IClosable source)
+    {
+        source.Close();
+    }
+
+    using unique_closable = std::unique_ptr<winrt::Windows::Foundation::IClosable, std::function<void(winrt::Windows::Foundation::IClosable)>>;
+    
+    /*using unique_closable_call = 
+        wil::unique_com_call<
+        winrt::Windows::Foundation::IClosable, 
+        decltype(&winrt::Windows::Foundation::IClosable::Close), 
+        &winrt::Windows::Foundation::IClosable::Close>;*/
+}


### PR DESCRIPTION
# OCR & clipboard images
OCR (Optical Character Recognition) will be performed on images copied into the clipboard. If the text matches a trigger, the corresponding action(s) will be created.

Clipboard history page now displays the images copied into the clipboard with the text that was recognized from that image displayed with the image.

#Allow duplicates
Implemented settings toggle to allow duplicated actions to be added. An action was classified as duplicated when the text that matched a trigger and thus created an action was the most recent in the action list, was copied another time.

# Defaulted settings
- Notifications are now defaulted to "Enabled".
- Add duplicated actions are now defaulted to "Enabled".

# Others
Various bug fixes.