### PR TITLE
V1.4.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,4 +363,3 @@ MigrationBackup/
 FodyWeavers.xsd
 
 # User
-/ClipboardManagerWixPackage/windowsappruntimeinstall-x64.exe

--- a/.gitignore
+++ b/.gitignore
@@ -361,7 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
-/ClipboardManagerBundle/windowsappruntimeinstall-x64.exe
-/ClipboardManager/user_file_copy.xml
+
+# User
 /ClipboardManagerWixPackage/windowsappruntimeinstall-x64.exe
-/ClipboardManagerBundle/VC_redist.x64.exe

--- a/ClipboardManager/CHANGELOG.md
+++ b/ClipboardManager/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Change log
 ## New
-`v1.4.3`
-- Removed log file as it crashes the application.
-
 `v1.4.0`
 - Log file (location can be modified in settings->dev options).
 
@@ -13,6 +10,14 @@
 - Search bar in actions page.
 
 ## Changes & Fixes
+`v1.4.4`
+- Moved log file to `~/Documents/`.
+- Messages bar now displays the last message instead of the first.
+- Improved settings category organization.
+
+`v1.4.3`
+- Removed log file as it crashes the application.
+
 `v1.4.0`
 - Changed message on startup when no triggers are loaded :
     - If no user file has been saved, info bar prompting to create/locate the user file.

--- a/ClipboardManager/CHANGELOG.md
+++ b/ClipboardManager/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 ## New
+`v1.4.3`
+- Removed log file as it crashes the application.
+
 `v1.4.0`
 - Log file (location can be modified in settings->dev options).
 
@@ -26,8 +29,10 @@
 
 ## Bugs
 - Outlook duplicates.
+- `.log` file requires elevation to create/write, making the application crash if it isn't run elevated.
 
 ## TODO
+- [ ] `ClipboardTriggerEditControl` Format text box, error border is not rounded or padded.
 - [ ] Tooltips (I18Ned).
 - [ ] Add translated error messages for regex errors :
     - [ ] Code 8 - "Found a closing ) with no corresponding opening parenthesis."

--- a/ClipboardManager/CHANGELOG.md
+++ b/ClipboardManager/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 ## New
+`v1.4.7`
+- Log file not enabled by default, can be enabled in settings.
+
 `v1.4.0`
 - Log file (location can be modified in settings->dev options).
 
@@ -10,6 +13,18 @@
 - Search bar in actions page.
 
 ## Changes & Fixes
+`v1.4.8`
+- `Logger` compile time string formatting (`std::format` and not `std::vformat`).
+- Application no longer displays "Logging backend not initialized" if the user hasn't enabled logging.
+
+`v1.4.5`
+- Added descriptions for the app log file path text box.
+- Fixed possible bug duplicating buttons when `ClipboardActionView` is loaded/unloaded by the `ScrollViewer` virtualization.
+- Improved start up experience for users when the app is missing a user file :
+    - File will be created empty when the user clicks the "Create" button.
+    - Upon closing, the app will write to the file any actions or triggers (even if none are created, a node will be created).
+    - If the file is emptied out by the user, or the app fails to save it a message will be shown to inform the user.
+
 `v1.4.4`
 - Moved log file to `~/Documents/`.
 - Messages bar now displays the last message instead of the first.
@@ -34,7 +49,7 @@
 
 ## Bugs
 - Outlook duplicates.
-- `.log` file requires elevation to create/write, making the application crash if it isn't run elevated.
+- ~~`.log` file requires elevation to create/write, making the application crash if it isn't run elevated.~~
 
 ## TODO
 - [ ] `ClipboardTriggerEditControl` Format text box, error border is not rounded or padded.

--- a/ClipboardManager/ClipboardActionEditor.xaml
+++ b/ClipboardManager/ClipboardActionEditor.xaml
@@ -17,9 +17,7 @@
         BorderThickness="1"
         Padding="16,10,16,16"
         CornerRadius="{StaticResource OverlayCornerRadius}"
-        RowSpacing="17"
-        PointerEntered="RootGrid_PointerEntered"
-        PointerExited="RootGrid_PointerExited">
+        RowSpacing="17">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="Auto"/>
@@ -123,7 +121,7 @@
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
 
-        <TextBlock x:Name="ActionLabelTextBlock" Grid.Row="0" Style="{StaticResource BodyStrongTextBlockStyle}" FontSize="20" VerticalAlignment="Center" Text="{x:Bind ActionLabel, Mode=OneWay}"/>
+        <TextBlock x:Name="ActionLabelTextBlock" Grid.Row="0" Style="{StaticResource BodyStrongTextBlockStyle}" FontSize="20" VerticalAlignment="Center" Text="{x:Bind ActionLabel, Mode=OneWay}" IsTextSelectionEnabled="True" />
         
         <Grid Grid.Row="1" Grid.ColumnSpan="2" ColumnSpacing="15">
             <Grid.ColumnDefinitions>
@@ -137,13 +135,14 @@
 
             <FontIcon x:Name="FormatErrorIconBackground" x:Load="False" Visibility="Collapsed" Glyph="&#xF136;" Foreground="{ThemeResource InfoBarErrorSeverityIconBackground}" Margin="0,0,4,0"/>
             <FontIcon x:Name="FormatErrorIcon" x:Load="False" Visibility="Collapsed" Glyph="&#xF13D;" Foreground="{ThemeResource InfoBarWarningSeverityIconForeground}" Margin="0,0,4,0"/>
-            
-            <TextBlock x:Name="ActionFormatTextBlock" VerticalAlignment="Center" TextWrapping="Wrap" Text="{x:Bind ActionFormat, Mode=OneWay}"/>
+
+            <TextBlock x:Name="ActionFormatTextBlock" VerticalAlignment="Center" TextWrapping="Wrap" Text="{x:Bind ActionFormat, Mode=OneWay}" IsTextSelectionEnabled="True" />
 
             <TextBlock 
                 x:Name="UseRegexMatchResultsTextBlock" 
                 x:Uid="UseRegexMatchResultsTextBlock"
                 Text="( )" 
+                IsTextSelectionEnabled="True" 
                 Grid.Column="1" 
                 VerticalAlignment="Center" 
                 HorizontalAlignment="Right" 
@@ -159,7 +158,7 @@
                 Padding="10,14,10,14" 
                 CornerRadius="{StaticResource ControlCornerRadius}" 
                 Margin="-4,4,-4,0">
-                <TextBlock x:Name="FormatErrorTextBlock" TextWrapping="Wrap" VerticalAlignment="Center"/>
+                <TextBlock x:Name="FormatErrorTextBlock" TextWrapping="Wrap" VerticalAlignment="Center" IsTextSelectionEnabled="True" />
             </Border>
         </Grid>
 
@@ -179,6 +178,7 @@
 
             <TextBlock 
                 x:Name="ActionRegexTextBlock" 
+                IsTextSelectionEnabled="True" 
                 Grid.Column="0"
                 FontFamily="Consolas" 
                 CharacterSpacing="70" 
@@ -202,7 +202,7 @@
             </StackPanel>
 
             <Border x:Name="RegexErrorBorder" x:Load="False" Visibility="Collapsed" Background="{ThemeResource SystemFillColorCriticalBackgroundBrush}" Grid.ColumnSpan="2" Grid.Row="1" Padding="10,14,10,14" CornerRadius="{StaticResource ControlCornerRadius}" Margin="-4,4,-4,0">
-                <TextBlock x:Name="RegexErrorTextBlock" TextWrapping="Wrap" VerticalAlignment="Center"/>
+                <TextBlock x:Name="RegexErrorTextBlock" TextWrapping="Wrap" VerticalAlignment="Center" IsTextSelectionEnabled="True" />
             </Border>
         </Grid>
 

--- a/ClipboardManager/ClipboardActionView.cpp
+++ b/ClipboardManager/ClipboardActionView.cpp
@@ -230,16 +230,21 @@ namespace winrt::ClipboardManager::implementation
 
     void ClipboardActionView::UserControl_Loading(ui::FrameworkElement const&, win::IInspectable const&)
     {
-        std::sort(triggers.begin(), triggers.end(), [this](auto&& a, auto&& b) -> bool
+        if (!loaded)
         {
-            return a.label().size() < b.label().size();
-        });
+            std::sort(triggers.begin(), triggers.end(), [this](auto&& a, auto&& b) -> bool
+            {
+                return a.label().size() < b.label().size();
+            });
 
-        // Create buttons for triggers:
-        for (auto&& action : triggers)
-        {
-            AddTriggerButton(action);
+            // Create buttons for triggers:
+            for (auto&& action : triggers)
+            {
+                AddTriggerButton(action);
+            }
         }
+
+        loaded = true;
     }
 
     void ClipboardActionView::OpenOptionsButton_Click(win::IInspectable const&, ui::RoutedEventArgs const&)

--- a/ClipboardManager/ClipboardActionView.h
+++ b/ClipboardManager/ClipboardActionView.h
@@ -43,6 +43,7 @@ namespace winrt::ClipboardManager::implementation
     private:
         static clip::utils::ResLoader resLoader;
 
+        bool loaded = false;
         clip::ui::VisualStateManager<ClipboardActionView> visualStateManager{ *this };
         using VisualState = clip::ui::VisualState<ClipboardActionView>;
         VisualState optionsClosedState{ L"OptionsClosed", 0, true };

--- a/ClipboardManager/ClipboardManager.cpp
+++ b/ClipboardManager/ClipboardManager.cpp
@@ -63,6 +63,8 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR,
     clip::utils::Console console{};
 #endif // ENABLE_CONSOLE
 
+    clip::utils::Logger logger{ L"WinMain" };
+
     try
     {
         auto dispatcherQueueController = clip::utils::managed_dispatcher_queue_controller(initIslandApp());
@@ -88,11 +90,13 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR,
     }
     catch (const winrt::hresult_error& error)
     {
+        logger.error(std::to_wstring(error.code().value));
         return error.code().value;
     }
     catch (...)
     {
-        std::wcout << L"Unknown error occured." << std::endl;
+        logger.error(L"Unknown error occured.");
+        //std::wcout << L"Unknown error occured." << std::endl;
     }
 
     return 0;
@@ -179,7 +183,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         { WM_SIZECLIPBOARD, L"WM_SIZECLIPBOARD" },
         { WM_VSCROLLCLIPBOARD, L"WM_VSCROLLCLIPBOARD" }
     };
-    //std::cout << "WndProc(message: " << message << ", wParam: " << wParam << ", lParam: " << lParam << ")" << std::endl;
 
     clip::utils::WindowInfo* windowInfo = clip::utils::getWindowInfo(hWnd);
     switch (message)
@@ -307,20 +310,19 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             break;
         }
 
-        case WM_ASKCBFORMATNAME: 
-        case WM_CHANGECBCHAIN: 
-        case WM_CLIPBOARDUPDATE: 
-        case WM_DESTROYCLIPBOARD: 
-        case WM_DRAWCLIPBOARD: 
-        case WM_HSCROLLCLIPBOARD: 
-        case WM_PAINTCLIPBOARD: 
-        case WM_RENDERALLFORMATS: 
-        case WM_RENDERFORMAT: 
-        case WM_SIZECLIPBOARD: 
+        case WM_ASKCBFORMATNAME:
+        case WM_CHANGECBCHAIN:
+        case WM_CLIPBOARDUPDATE:
+        case WM_DESTROYCLIPBOARD:
+        case WM_DRAWCLIPBOARD:
+        case WM_HSCROLLCLIPBOARD:
+        case WM_PAINTCLIPBOARD:
+        case WM_RENDERALLFORMATS:
+        case WM_RENDERFORMAT:
+        case WM_SIZECLIPBOARD:
         case WM_VSCROLLCLIPBOARD:
             logger.info(L"WM clipboard message: " + std::wstring(windowMessages[message]));
-            break;
-
+            [[fallthrough]];
         default:
             return DefWindowProc(hWnd, message, wParam, lParam);
     }
@@ -374,6 +376,8 @@ bool processMessageForTabNav(const HWND& window, MSG& msg)
 
 void createWinUIWindow(clip::utils::WindowInfo* windowInfo, const HWND& windowHandle)
 {
+    clip::utils::Logger logger{ L"createWinUIWindow" };
+
     assert(windowInfo == nullptr);
 
     windowInfo = new clip::utils::WindowInfo();
@@ -381,6 +385,7 @@ void createWinUIWindow(clip::utils::WindowInfo* windowInfo, const HWND& windowHa
 
     windowInfo->desktopWinXamlSrc = winrt::DesktopWindowXamlSource();
     windowInfo->desktopWinXamlSrc.Initialize(winrt::GetWindowIdFromWindow(windowHandle));
+    logger.info(L"Initialized `DesktopWindowXamlSource`.");
     // Enable the DesktopWindowXamlSource to be a tab stop.
     SetWindowLong(winrt::GetWindowFromWindowId(windowInfo->desktopWinXamlSrc.SiteBridge().WindowId()), GWL_STYLE, WS_TABSTOP | WS_CHILD | WS_VISIBLE);
 
@@ -388,6 +393,7 @@ void createWinUIWindow(clip::utils::WindowInfo* windowInfo, const HWND& windowHa
 
     // Put a new instance of our Xaml "MainPage" into our island.  This is our UI content.
     windowInfo->desktopWinXamlSrc.Content(winrt::make<winrt::ClipboardManager::implementation::MainPage>(appWindow));
+    logger.info(L"Window content created. Moving app window.");
 
     clip::Settings settings{};
     int32_t x = settings.get<int32_t>(L"WindowPosX").value_or(10);
@@ -441,7 +447,17 @@ void createWinUIWindow(clip::utils::WindowInfo* windowInfo, const HWND& windowHa
             resources.TryLookup(winrt::box_value(L"ButtonForegroundColor")).as<winrt::Windows::UI::Color>());
     }
 
-    AddClipboardFormatListener(windowHandle); // outlook-bug
+    auto added = AddClipboardFormatListener(windowHandle); // outlook-bug
+    if (!added)
+    {
+        logger.error(L"Not added to clipboard format listeners.");
+    }
+    else
+    {
+        logger.info(L"Added to clipboard format listeners.");
+    }
+
+    logger.info(L"Created WinUI window.");
 }
 
 void handleWindowActivation(clip::utils::WindowInfo* windowInfo, const bool& inactive)

--- a/ClipboardManager/ClipboardManager.vcxproj
+++ b/ClipboardManager/ClipboardManager.vcxproj
@@ -153,6 +153,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <TreatSpecificWarningsAsErrors>4715;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -174,6 +175,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/ClipboardManager/ClipboardManager.vcxproj
+++ b/ClipboardManager/ClipboardManager.vcxproj
@@ -152,7 +152,7 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <TreatSpecificWarningsAsErrors>4715;%(TreatSpecificWarningsAsErrors)</TreatSpecificWarningsAsErrors>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/ClipboardManager/ClipboardManager.vcxproj
+++ b/ClipboardManager/ClipboardManager.vcxproj
@@ -171,8 +171,9 @@
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp20</LanguageStandard>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/ClipboardManager/ClipboardTriggerEditControl.xaml
+++ b/ClipboardManager/ClipboardTriggerEditControl.xaml
@@ -46,6 +46,7 @@
                         <Setter Target="FormatTextBoxBorder.Margin" Value="-5,-7"/>
                         <Setter Target="FormatTextBoxErrorIcon.Visibility" Value="Visible"/>
                         <Setter Target="FormatTextBoxError.Visibility" Value="Visible"/>
+                        <Setter Target="FormatTextBoxWarningBorder.Margin" Value="-5,10,-5,-7"/>
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -64,6 +65,7 @@
                         <Setter Target="FormatTextBoxBorder.Margin" Value="-5,-7"/>
                         <Setter Target="FormatTextBoxErrorIcon.Visibility" Value="Visible"/>
                         <Setter Target="FormatTextBoxError.Visibility" Value="Visible"/>
+                        <Setter Target="FormatTextBoxWarningBorder.Margin" Value="-5,10,-5,-7"/>
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -73,7 +75,7 @@
                 <VisualState x:Name="FormatProtocolWarning">
                     <VisualState.Setters>
                         <Setter Target="FormatTextBoxWarningBorder.Visibility" Value="Visible"/>
-                        <Setter Target="FormatTextBoxWarningBorder.Margin" Value="0,3,0,0"/>
+                        <Setter Target="FormatTextBoxWarningBorder.Margin" Value="-5,10,-5,-7"/>
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/ClipboardManager/MainPage.cpp
+++ b/ClipboardManager/MainPage.cpp
@@ -1108,11 +1108,11 @@ namespace winrt::ClipboardManager::implementation
     {
         loaded = false;
 
-        clipboardContentChangedToken = win::Clipboard::HistoryChanged({ this, &MainPage::ClipboardContent_Changed });
-        win::Clipboard::ContentChanged([this](auto&&, auto&&)
+        clipboardContentChangedToken = win::Clipboard::ContentChanged({ this, &MainPage::ClipboardContent_Changed });
+        /*win::Clipboard::ContentChanged([this](auto&&, auto&&)
         {
             logger.info(L"Clipboard CONTENT changed.");
-        });
+        });*/
 
         appWindow.Changed([this](auto, xaml::AppWindowChangedEventArgs args)
         {
@@ -1152,9 +1152,9 @@ namespace winrt::ClipboardManager::implementation
         }
 
         auto&& appVersionSetting = localSettings.get<std::wstring>(L"CurrentAppVersion");
+        clip::utils::AppVersion appVersion{};
         if (appVersionSetting.has_value())
         {
-            clip::utils::AppVersion appVersion{ APP_VERSION };
             clip::utils::AppVersion storedAppVersion{ appVersionSetting.value() };
             if (appVersion.major() < storedAppVersion.major())
             {
@@ -1171,7 +1171,7 @@ namespace winrt::ClipboardManager::implementation
                 visualStateManager.goToState(firstStartupState);
             }
         }
-        localSettings.insert(L"CurrentAppVersion", APP_VERSION);
+        localSettings.insert(L"CurrentAppVersion", appVersion.versionString());
 
         if (!localSettings.get<std::wstring>(L"UserFilePath"))
         {
@@ -1218,12 +1218,7 @@ namespace winrt::ClipboardManager::implementation
         if (storageFile)
         {
             std::filesystem::path userFilePath{ storageFile.Path().c_str() };
-
-            if (LoadTriggers(userFilePath))
-            {
-                ReloadActions();
-                visualStateManager.goToState(openSaveFileState);
-            }
+            localSettings.insert(L"UserFilePath", userFilePath);
         }
     }
 
@@ -1433,6 +1428,8 @@ namespace winrt::ClipboardManager::implementation
             trigger.updateMatchMode(useSearch ? clip::MatchMode::Search : clip::MatchMode::Match);
             trigger.useRegexMatchResults(useRegexMatchResults);
             triggers.push_back(trigger);
+
+            //logger.info(L"Created new trigger: ")
 
             clipboardTriggerViews.InsertAt(0, CreateTriggerView(trigger));
         }

--- a/ClipboardManager/MainPage.cpp
+++ b/ClipboardManager/MainPage.cpp
@@ -49,6 +49,7 @@
 #include <limits>
 #include <format>
 #include <map>
+#include <ranges>
 
 namespace xaml
 {
@@ -231,6 +232,9 @@ namespace winrt::ClipboardManager::implementation
                     appWindow.Hide();
                 }
                 break;
+            case WM_CLIPBOARDUPDATE:
+                ClipboardContent_Changed(nullptr, nullptr);
+                break;
         }
     }
 
@@ -239,6 +243,19 @@ namespace winrt::ClipboardManager::implementation
     {
         // Load triggers:
         LoadUserFile(std::nullopt);
+
+        if (localSettings.get<bool>(L"InterpretWMClipboardMessages").value_or(false))
+        {
+            logger.info(L"Interpreting WM clipboard messages instead of using WASDK events.");
+        }
+        else
+        {
+            clipboardContentChangedToken = win::Clipboard::ContentChanged({ this, &MainPage::ClipboardContent_Changed });
+            /*win::Clipboard::ContentChanged([this](auto&&, auto&&)
+            {
+                logger.info(L"Clipboard CONTENT changed.");
+            });*/
+        }
 
         try
         {
@@ -274,12 +291,6 @@ namespace winrt::ClipboardManager::implementation
                 TitleBarGrid().Children().RemoveAt(index);
             }
         }
-
-        auto&& presenter = appWindow.Presenter().try_as<xaml::OverlappedPresenter>();
-        if (presenter)
-        {
-            WindowButtonsColumn().Width(xaml::GridLengthHelper::FromPixels(presenter.IsMinimizable() ? 135 : 45));
-        }
     }
 
     void MainPage::ReloadActions()
@@ -309,6 +320,8 @@ namespace winrt::ClipboardManager::implementation
 
     bool MainPage::LoadTriggers(std::filesystem::path& path)
     {
+        logger.info(L"*Loading triggers*");
+
         if (!std::filesystem::exists(path))
         {
             logger.info(L"User file path doesn't exist.");
@@ -322,9 +335,8 @@ namespace winrt::ClipboardManager::implementation
 
         try
         {
-            logger.info(L"*Loading triggers*");
             triggers = clip::ClipboardTrigger::loadClipboardTriggers(path);
-            logger.info(std::format(L"{} triggers on disk.", triggers.size()));
+            logger.info(std::format(L"{} triggers in file.", triggers.size()));
 
             if (!triggers.empty())
             {
@@ -412,6 +424,8 @@ namespace winrt::ClipboardManager::implementation
 
     bool MainPage::LoadUserFile(std::optional<std::filesystem::path>&& userFilePath)
     {
+        logger.info(L"*Loading user file*");
+
         bool triggersLoaded = false;
 
         if (!userFilePath)
@@ -421,49 +435,26 @@ namespace winrt::ClipboardManager::implementation
 
         if (userFilePath.has_value() && clip::utils::pathExists(userFilePath.value()))
         {
-            if (!(triggersLoaded = LoadTriggers(userFilePath.value())))
+            if ((triggersLoaded = LoadTriggers(userFilePath.value())))
+            {
+                LoadHistory(userFilePath.value());
+
+                // Enable file watcher:
+                try
+                {
+                    if (localSettings.get<bool>(L"EnableTriggerFileWatching").value_or(false))
+                    {
+                        watcher.startWatching(userFilePath.value());
+                    }
+                }
+                catch (std::wstring message)
+                {
+                    logger.error(L"Error enabling file watcher: " + message);
+                }
+            }
+            else
             {
                 logger.info(L"Failed to load triggers.");
-            }
-
-            // Load history:
-            try
-            {
-                boost::property_tree::wptree tree{};
-                boost::property_tree::read_xml(userFilePath.value().string(), tree);
-                for (auto&& historyItem : tree.get_child(L"settings.history"))
-                {
-                    try
-                    {
-                        clip::ClipboardAction action{ historyItem.second };
-                        auto text = action.text();
-                        auto time = action.creationTime();
-
-                        AddAction(action, false);
-                    }
-                    catch (std::format_error error)
-                    {
-                        logger.error(error.what());
-                    }
-
-                }
-            }
-            catch (const boost::property_tree::ptree_bad_path badPath)
-            {
-                logger.error(L"Failed to retreive history from user file: " + clip::utils::to_wstring(badPath.what()));
-            }
-
-            // Enable file watcher:
-            try
-            {
-                if (localSettings.get<bool>(L"EnableTriggerFileWatching").value_or(false))
-                {
-                    watcher.startWatching(userFilePath.value());
-                }
-            }
-            catch (std::wstring message)
-            {
-                logger.error(L"Error enabling file watcher: " + message);
             }
         }
         else if (userFilePath)
@@ -476,6 +467,46 @@ namespace winrt::ClipboardManager::implementation
 
         return triggersLoaded;
     }
+
+    async MainPage::LoadHistory(std::filesystem::path userFilePath)
+    {
+        co_await resume_background();
+
+        // Load history:
+        try
+        {
+            logger.info(L"*Loading actions history*");
+
+            uint32_t count = 0;
+            boost::property_tree::wptree tree{};
+            boost::property_tree::read_xml(userFilePath.string(), tree);
+            for (auto&& historyItem : tree.get_child(L"settings.history"))
+            {
+                DispatcherQueue().TryEnqueue([this, action = clip::ClipboardAction(historyItem.second)]()
+                {
+                    AddAction(action, false);
+                });
+                
+                if (count++ > localSettings.get<uint32_t>(L"ActionHistoryMaxCount").value_or(200))
+                {
+                    DispatcherQueue().TryEnqueue([this]()
+                    {
+                        MessagesBar().AddWarning(L"UserMessage_TooManyActions", L"Too many actions in history.");
+                    });
+
+                    break;
+                }
+            }
+        }
+        catch (const boost::property_tree::ptree_bad_path& badPath)
+        {
+            logger.error(L"Failed to retreive history from user file: " + clip::utils::to_wstring(badPath.what()));
+        }
+        catch (const boost::property_tree::xml_parser_error& parserError)
+        {
+            logger.error(L"Failed to retreive history from user file: " + clip::utils::to_wstring(parserError.what()));
+        }
+    }
     
     void MainPage::AddAction(const clip::ClipboardAction& action, const bool& notify)
     {
@@ -487,7 +518,7 @@ namespace winrt::ClipboardManager::implementation
             actionView.Timestamp(clock::from_sys(action.creationTime()));
 
             std::vector<std::pair<std::wstring, std::wstring>> buttons{};
-            if (FindActions(actionView, buttons, action.text()))
+            if (FindActions(actionView, action.text(), notify, buttons))
             {
                 clipboardActionViews.InsertAt(0, actionView);
                 actionView.Removed([this](auto&& sender, auto&&)
@@ -507,10 +538,10 @@ namespace winrt::ClipboardManager::implementation
         }
     }
 
-    bool MainPage::FindActions(winrt::ClipboardManager::ClipboardActionView& actionView,
-                               std::vector<std::pair<std::wstring, std::wstring>>& buttons, const std::wstring& text)
+    bool MainPage::FindActions(winrt::ClipboardManager::ClipboardActionView& actionView, const std::wstring& text, 
+                               const bool& notify, std::vector<std::pair<std::wstring, std::wstring>>& buttons)
     {
-        auto matchMode = localSettings.get<clip::MatchMode>(L"TriggerMatchMode");
+        const auto matchMode = localSettings.get<clip::MatchMode>(L"TriggerMatchMode");
 
         bool hasMatch = false;
         for (auto&& trigger : triggers)
@@ -522,16 +553,19 @@ namespace winrt::ClipboardManager::implementation
                 actionView.AddAction(trigger.label(), trigger.format(), trigger.regex().str(), true, 
                                      trigger.useRegexMatchResults(), trigger.regex().flags() & boost::regex_constants::icase);
 
-                try
+                if (notify)
                 {
-                    auto url = trigger.formatTrigger(text);
-                    buttons.push_back({ trigger.label(), url });
-                }
-                catch (std::invalid_argument formatError)
-                {
-                    logger.error(clip::utils::to_wstring(formatError.what()));
+                    try
+                    {
+                        const auto url = trigger.formatTrigger(text);
+                        buttons.push_back({ trigger.label(), url });
+                    }
+                    catch (std::invalid_argument formatError)
+                    {
+                        logger.error(clip::utils::to_wstring(formatError.what()));
 
-                    MessagesBar().AddWarning(L"", L"Failed to create format for trigger " + trigger.label());
+                        MessagesBar().AddWarning(trigger.label(), L"Failed to create format for trigger " + trigger.label());
+                    }
                 }
             }
         }
@@ -606,14 +640,13 @@ namespace winrt::ClipboardManager::implementation
     {
         if (content.Contains(win::StandardDataFormats::Text()))
         {
+            clip::utils::ClipboardSourceFinder clipboardSourceFinder{};
+
             auto&& itemText = co_await content.GetTextAsync();
             if (!itemText.empty())
             {
-                DispatcherQueue().TryEnqueue([this, text = std::wstring(itemText), notify]()
-                {
-                    // Run triggers on the text:
-                    AddAction(clip::ClipboardAction(text), notify);
-                });
+                // Run triggers on the text:
+                AddAction(clip::ClipboardAction(std::wstring(itemText)), notify);
             }
         }
     }
@@ -934,7 +967,7 @@ namespace winrt::ClipboardManager::implementation
         return *this;
     }
 
-    async MainPage::ClipboardContent_Changed(const win::IInspectable& s, const win::IInspectable& e)
+    async MainPage::ClipboardContent_Changed(const win::IInspectable&, const win::IInspectable&)
     {
         using namespace std::literals;
         static std::chrono::system_clock::time_point lastEntry{};
@@ -955,7 +988,7 @@ namespace winrt::ClipboardManager::implementation
         else
         {
             clip::utils::clipboard_properties_formatter formatter{};
-            logger.info(L"Clipboard HISTORY changed: " + formatter.format(content));
+            logger.debug(L"Clipboard HISTORY changed: " + formatter.format(content));
 
             co_await AddClipboardItem(content, true);
         }
@@ -1104,16 +1137,39 @@ namespace winrt::ClipboardManager::implementation
         SetDragRectangles();
     }
 
-    winrt::async MainPage::Page_Loading(xaml::FrameworkElement const&, win::IInspectable const&)
+    void MainPage::Page_Loading(xaml::FrameworkElement const&, win::IInspectable const&)
     {
         loaded = false;
+        Restore();
+    }
 
-        clipboardContentChangedToken = win::Clipboard::ContentChanged({ this, &MainPage::ClipboardContent_Changed });
-        /*win::Clipboard::ContentChanged([this](auto&&, auto&&)
+    void MainPage::Page_Loaded(win::IInspectable const&, xaml::RoutedEventArgs const&)
+    {
+        //Restore();
+
+        // Minimize app window if the user requested to :
+        if (localSettings.get<bool>(L"StartWindowMinimized").value_or(false))
         {
-            logger.info(L"Clipboard CONTENT changed.");
-        });*/
+            if (activationHotKey.registered() && localSettings.get<bool>(L"HideAppWindow").value_or(false))
+            {
+                overlayEnabled.set(true);
+                appWindow.Hide();
+            }
+            else
+            {
+                appWindow.Presenter().as<xaml::OverlappedPresenter>().Minimize();
+            }
+        }
 
+        // Adapt grid window button column from the state of the presenter :
+        auto&& presenter = appWindow.Presenter().try_as<xaml::OverlappedPresenter>();
+        if (presenter)
+        {
+            WindowButtonsColumn().Width(xaml::GridLengthHelper::FromPixels(presenter.IsMinimizable() ? 135 : 45));
+        }
+
+        // Adapt triggers page UI from the size of the window :
+        visualStateManager.goToState(appWindow.Size().Width < 930 ? under1kState : over1kState);
         appWindow.Changed([this](auto, xaml::AppWindowChangedEventArgs args)
         {
             if (args.DidSizeChange())
@@ -1129,28 +1185,7 @@ namespace winrt::ClipboardManager::implementation
             }
         });
 
-        co_return;
-    }
-
-    void MainPage::Page_Loaded(win::IInspectable const&, xaml::RoutedEventArgs const&)
-    {
-        Restore();
-
-        visualStateManager.goToState(appWindow.Size().Width < 930 ? under1kState : over1kState);
-
-        if (localSettings.get<bool>(L"StartWindowMinimized").value_or(false))
-        {
-            if (activationHotKey.registered() && localSettings.get<bool>(L"HideAppWindow").value_or(false))
-            {
-                overlayEnabled.set(true);
-                appWindow.Hide();
-            }
-            else
-            {
-                appWindow.Presenter().as<xaml::OverlappedPresenter>().Minimize();
-            }
-        }
-
+        // Check app version and display a message to the user if it has gone a major update :
         auto&& appVersionSetting = localSettings.get<std::wstring>(L"CurrentAppVersion");
         clip::utils::AppVersion appVersion{};
         if (appVersionSetting.has_value())
@@ -1173,11 +1208,13 @@ namespace winrt::ClipboardManager::implementation
         }
         localSettings.insert(L"CurrentAppVersion", appVersion.versionString());
 
+        // Check if a user file has been saved, if not show a message to the user :
         if (!localSettings.get<std::wstring>(L"UserFilePath"))
         {
             visualStateManager.goToState(noUserFilePathSavedState);
         }
 
+        // Show a message that the logging backend has not been initialized if it hasn't :
         if (!logger.isLogBackendInitialized())
         {
             MessagesBar().AddMessage(L"Logging backend is not initialized.");
@@ -1486,26 +1523,6 @@ namespace winrt::ClipboardManager::implementation
     void MainPage::SearchActionsAutoSuggestBox_GotFocus(win::IInspectable const&, xaml::RoutedEventArgs const&)
     {
         RefreshSearchBoxSuggestions(std::wstring(SearchActionsAutoSuggestBox().Text()));
-    }
-
-    void MainPage::SearchActionsAutoSuggestBox_SuggestionChosen(xaml::AutoSuggestBox const& sender, xaml::AutoSuggestBoxSuggestionChosenEventArgs const& args)
-    {
-        /*SearchActionsListView().Items().Clear();
-        auto selectedItem = args.SelectedItem().try_as<hstring>();
-        if (selectedItem.has_value())
-        {
-            visualStateManager.goToState(showSearchListViewState);
-
-            boost::wregex regex{ std::wstring(selectedItem.value()), boost::regex_constants::icase };
-            for (auto&& view : clipboardActionViews)
-            {
-                auto text = static_cast<std::wstring>(view.Text());
-                if (boost::regex_match(text, regex))
-                {
-                    SearchActionsListView().Items().Append(box_value(view.Text()));
-                }
-            }
-        }*/
     }
 
     void MainPage::SearchBoxGrid_Loading(xaml::FrameworkElement const&, win::IInspectable const&)

--- a/ClipboardManager/MainPage.h
+++ b/ClipboardManager/MainPage.h
@@ -84,13 +84,15 @@ namespace winrt::ClipboardManager::implementation
 
         void Restore();
         void AddAction(const clip::ClipboardAction& action, const bool& notify);
-        bool FindActions(winrt::ClipboardManager::ClipboardActionView& actionView, std::vector<std::pair<std::wstring, std::wstring>>& buttons, const std::wstring& text);
+        bool FindActions(winrt::ClipboardManager::ClipboardActionView& actionView, const std::wstring& text, 
+                         const bool& notify, std::vector<std::pair<std::wstring, std::wstring>>& buttons);
         void SendNotification(const std::vector<std::pair<std::wstring, std::wstring>>& buttons);
         void ReloadActions();
         bool LoadTriggers(std::filesystem::path& path);
         void LaunchAction(const std::wstring& url);
         async AddClipboardItem(const Windows::ApplicationModel::DataTransfer::DataPackageView& content, const bool& notify);
         bool LoadUserFile(std::optional<std::filesystem::path>&& path);
+        async LoadHistory(std::filesystem::path path);
         ClipboardManager::ClipboardActionEditor CreateTriggerView(clip::ClipboardTrigger& trigger);
         void RefreshSearchBoxSuggestions(std::wstring text);
         void FillSearchBoxSuggestions(const Windows::Foundation::Collections::IVector<IInspectable>& list, const SearchFilter& searchFilter, std::wstring text);
@@ -113,7 +115,7 @@ namespace winrt::ClipboardManager::implementation
 
     public:
         void Page_SizeChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::SizeChangedEventArgs const& e);
-        winrt::async Page_Loading(winrt::Microsoft::UI::Xaml::FrameworkElement const& sender, winrt::Windows::Foundation::IInspectable const& args);
+        void Page_Loading(winrt::Microsoft::UI::Xaml::FrameworkElement const& sender, winrt::Windows::Foundation::IInspectable const& args);
         winrt::async LocateUserFileButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
         winrt::async CreateUserFileButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
         void Page_Loaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
@@ -133,7 +135,6 @@ namespace winrt::ClipboardManager::implementation
         void OpenSearchButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
         void SearchActionsAutoSuggestBox_TextChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::TextChangedEventArgs const& args);
         void SearchActionsAutoSuggestBox_GotFocus(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
-        void SearchActionsAutoSuggestBox_SuggestionChosen(winrt::Microsoft::UI::Xaml::Controls::AutoSuggestBox const& sender, winrt::Microsoft::UI::Xaml::Controls::AutoSuggestBoxSuggestionChosenEventArgs const& args);
         void SearchBoxGrid_Loading(winrt::Microsoft::UI::Xaml::FrameworkElement const& sender, winrt::Windows::Foundation::IInspectable const& args);
         void CompactModeToggleButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
         void SearchActionsListView_DoubleTapped(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Input::DoubleTappedRoutedEventArgs const& e);

--- a/ClipboardManager/MainPage.h
+++ b/ClipboardManager/MainPage.h
@@ -64,6 +64,7 @@ namespace winrt::ClipboardManager::implementation
         clip::ui::VisualState<MainPage> searchOpenState{ L"SearchOpened", 6, false };
         clip::ui::VisualState<MainPage> showActionsListViewState{ L"ShowActionsListView", 7, true };
         clip::ui::VisualState<MainPage> showSearchListViewState{ L"ShowSearchListView", 7, false };
+        clip::ui::VisualState<MainPage> userFilePathSavedState{ L"UserFilePathSaved", 8, true };
         clip::ui::VisualState<MainPage> noUserFilePathSavedState{ L"NoUserFilePathSaved", 8, false };
 
         bool loaded = false;

--- a/ClipboardManager/MainPage.xaml
+++ b/ClipboardManager/MainPage.xaml
@@ -326,7 +326,7 @@
                     <FontIcon x:Name="ClipboardActionsPivot" Glyph="&#xea8a;" FontSize="16"/>
                 </PivotItem.Header>
 
-                <Grid Padding="5,3,5,0">
+                <Grid Padding="5,0,5,5">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>

--- a/ClipboardManager/MainPage.xaml
+++ b/ClipboardManager/MainPage.xaml
@@ -63,6 +63,7 @@
             </VisualStateGroup>
 
             <VisualStateGroup>
+                <VisualState x:Name="UserFilePathSaved"/>
                 <VisualState x:Name="NoUserFilePathSaved">
                     <VisualState.Setters>
                         <Setter Target="NoClipboardActionsInfoBar.Visibility" Value="Visible"/>
@@ -372,11 +373,7 @@
                             x:Name="CreateActionsInfoBar"
                             x:Uid="OpenSaveFileInfoBar"
                             x:Load="False"
-                            Severity="Success">
-                            <InfoBar.Content>
-                                <HyperlinkButton x:Uid="CreateActionsButton" IsEnabled="False" HorizontalAlignment="Stretch" MaxWidth="150" Margin="0,0,0,5"/>
-                            </InfoBar.Content>
-                        </InfoBar>
+                            Severity="Success"/>
 
                         <InfoBar 
                             x:Name="ViewActionsInfoBar"

--- a/ClipboardManager/MessagesBar.cpp
+++ b/ClipboardManager/MessagesBar.cpp
@@ -22,6 +22,10 @@ namespace winrt::ClipboardManager::implementation
         {
             LoadFirst();
         }
+        else
+        {
+            Select(infoBars.size() - 1, true);
+        }
     }
 
     void MessagesBar::Add(const winrt::hstring& titleKey, const winrt::hstring& altTitle, const winrt::hstring& messageKey, const winrt::hstring& messageAlt)
@@ -87,9 +91,12 @@ namespace winrt::ClipboardManager::implementation
 
     void MessagesBar::UserControl_Loaded(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e)
     {
-        // Load first control
-        loaded = true;
-        LoadFirst();
+        if (!loaded)
+        {
+            // Load first control
+            loaded = true;
+            LoadFirst();
+        }
     }
 
     void MessagesBar::LeftButton_Click(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e)
@@ -105,13 +112,7 @@ namespace winrt::ClipboardManager::implementation
     void MessagesBar::PipsPager_SelectedIndexChanged(winrt::Microsoft::UI::Xaml::Controls::PipsPager const& sender, winrt::Microsoft::UI::Xaml::Controls::PipsPagerSelectedIndexChangedEventArgs const& args)
     {
         auto selectedIndex = static_cast<size_t>(sender.SelectedPageIndex());
-
-        if (selectedIndex < infoBars.size() && selectedIndex >= 0)
-        {
-            index = selectedIndex;
-            ContentPresenter().Content(infoBars[index]);
-            //PipsPager().SelectedPageIndex(index);
-        }
+        Select(selectedIndex, false);
     }
 
 
@@ -119,9 +120,8 @@ namespace winrt::ClipboardManager::implementation
     {
         if (loaded && !infoBars.empty())
         {
-            ContentPresenter().Content(infoBars[0]);
+            Select(0, true);
             PipsPager().NumberOfPages(static_cast<int32_t>(infoBars.size()));
-            visualStateManager.goToState(openState);
         }
     }
 
@@ -129,8 +129,7 @@ namespace winrt::ClipboardManager::implementation
     {
         if ((index + 1) < infoBars.size())
         {
-            ContentPresenter().Content(infoBars[++index]);
-            PipsPager().SelectedPageIndex(static_cast<int32_t>(index));
+            Select(++index, true);
         }
     }
 
@@ -138,8 +137,7 @@ namespace winrt::ClipboardManager::implementation
     {
         if (index > 0)
         {
-            ContentPresenter().Content(infoBars[--index]);
-            PipsPager().SelectedPageIndex(static_cast<int32_t>(index));
+            Select(--index, true);
         }
     }
 
@@ -178,20 +176,39 @@ namespace winrt::ClipboardManager::implementation
                 }
             }
 
-            PipsPager().NumberOfPages(static_cast<int32_t>(infoBars.size()));
-            InfoBadge().Value(static_cast<int32_t>(infoBars.size()));
-
-            if (i < infoBars.size())
-            {
-                ContentPresenter().Content(infoBars[index]);
-            }
-
             if (infoBars.empty())
             {
                 visualStateManager.goToState(closedState);
             }
+            else if (i < infoBars.size())
+            {
+                Select(i, true);
+            }
+            else
+            {
+                Select(i - 1, true);
+            }
+
+            PipsPager().NumberOfPages(static_cast<int32_t>(infoBars.size()));
+            InfoBadge().Value(static_cast<int32_t>(infoBars.size()));
         });
 
         return infoBar;
+    }
+
+    void MessagesBar::Select(const size_t& selectedIndex, const bool& movePager)
+    {
+        if (selectedIndex < infoBars.size() && selectedIndex >= 0)
+        {
+            index = selectedIndex;
+            
+            ContentPresenter().Content(infoBars[index]);
+            if (movePager)
+            {
+                PipsPager().SelectedPageIndex(static_cast<int32_t>(index));
+            }
+
+            visualStateManager.goToState(openState);
+        }
     }
 }

--- a/ClipboardManager/MessagesBar.h
+++ b/ClipboardManager/MessagesBar.h
@@ -50,6 +50,7 @@ namespace winrt::ClipboardManager::implementation
             const winrt::hstring& message, 
             const winrt::Microsoft::UI::Xaml::Controls::InfoBarSeverity& severity,
             const Windows::Foundation::IInspectable& content = nullptr);
+        void Select(const size_t& index, const bool& movePager);
     };
 }
 

--- a/ClipboardManager/Resources.lang-en-us.resw
+++ b/ClipboardManager/Resources.lang-en-us.resw
@@ -845,4 +845,19 @@ If you are using multiple placeholders '{}' index them (ex: \\{0\\}...\\{0\\}).<
   <data name="UserMessage_XNumberOfTriggersLoaded" xml:space="preserve">
     <value>{} triggers loaded.</value>
   </data>
+  <data name="HeaderActionsTextBlock.Text" xml:space="preserve">
+    <value>Actions</value>
+  </data>
+  <data name="HeaderClipboardTextBlock.Text" xml:space="preserve">
+    <value>Clipboard</value>
+  </data>
+  <data name="ClipboardEventingHostControl.Title" xml:space="preserve">
+    <value>Clipboard events</value>
+  </data>
+  <data name="ClipboardEventingHostControl.Subtitle" xml:space="preserve">
+    <value>Use Windows native events</value>
+  </data>
+  <data name="UserMessage_TooManyActions" xml:space="preserve">
+    <value>Too many actions in history, a limited number of actions have been restored.</value>
+  </data>
 </root>

--- a/ClipboardManager/Resources.lang-en-us.resw
+++ b/ClipboardManager/Resources.lang-en-us.resw
@@ -482,7 +482,7 @@ You can easily access your user file via settings and see an example of a valid 
     <value>Open &amp; edit</value>
   </data>
   <data name="OpenSaveFileInfoBar.Message" xml:space="preserve">
-    <value>One default trigger has been added as a template, do you want to edit it ?</value>
+    <value>The current user file is currently empty.</value>
   </data>
   <data name="OpenSaveFileInfoBar.Title" xml:space="preserve">
     <value>Save file successfully created !</value>
@@ -829,9 +829,6 @@ If you are using multiple placeholders '{}' index them (ex: \\{0\\}...\\{0\\}).<
   </data>
   <data name="UserFileSaveContentDialog.PrimaryButtonText" xml:space="preserve">
     <value>Create file</value>
-  </data>
-  <data name="LogFilePathHostControl.Header" xml:space="preserve">
-    <value>Log file path</value>
   </data>
   <data name="LogFilePathNokTextBlock.Text" xml:space="preserve">
     <value>Path does not exist.</value>

--- a/ClipboardManager/Resources.lang-fr-fr.resw
+++ b/ClipboardManager/Resources.lang-fr-fr.resw
@@ -570,7 +570,7 @@ Vous pouvez facilement accéder à votre fichier utilisateur via les paramètres
     <comment>MainPage</comment>
   </data>
   <data name="OpenSaveFileInfoBar.Message" xml:space="preserve">
-    <value>Une action a été ajoutée en tant qu'example, voulez-vous la modifier ?</value>
+    <value>Le fichier utilisateur est actuellement vide.</value>
     <comment>MainPage</comment>
   </data>
   <data name="OpenSaveFileInfoBar.Title" xml:space="preserve">
@@ -977,9 +977,6 @@ Si vous utilisez plusieurs fois {} indexez les (ex: \\{0\\}....\\{0\\}).</value>
   </data>
   <data name="UserFileSaveContentDialog.PrimaryButtonText" xml:space="preserve">
     <value>Créer</value>
-  </data>
-  <data name="LogFilePathHostControl.Header" xml:space="preserve">
-    <value>Chemin du fichier de log</value>
   </data>
   <data name="LogFilePathNokTextBlock.Text" xml:space="preserve">
     <value>Le chemin n'existe pas.</value>

--- a/ClipboardManager/Resources.lang-fr-fr.resw
+++ b/ClipboardManager/Resources.lang-fr-fr.resw
@@ -993,4 +993,19 @@ Si vous utilisez plusieurs fois {} indexez les (ex: \\{0\\}....\\{0\\}).</value>
   <data name="UserMessage_XNumberOfTriggersLoaded" xml:space="preserve">
     <value>{} déclencheurs chargés.</value>
   </data>
+  <data name="HeaderActionsTextBlock.Text" xml:space="preserve">
+    <value>Actions</value>
+  </data>
+  <data name="HeaderClipboardTextBlock.Text" xml:space="preserve">
+    <value>Presse-papier</value>
+  </data>
+  <data name="ClipboardEventingHostControl.Title" xml:space="preserve">
+    <value>Evènements presse-papier</value>
+  </data>
+  <data name="ClipboardEventingHostControl.Subtitle" xml:space="preserve">
+    <value>Utiliser les évènements Windows natifs</value>
+  </data>
+  <data name="UserMessage_TooManyActions" xml:space="preserve">
+    <value>Trop d'actions en historique, le nombre dernières actions restorées est limité.</value>
+  </data>
 </root>

--- a/ClipboardManager/Resources.resw
+++ b/ClipboardManager/Resources.resw
@@ -844,8 +844,8 @@ You can easily access your user file via settings and see an example of a valid 
     <value>Create file</value>
     <comment>MainPage</comment>
   </data>
-  <data name="LogFilePathHostControl.Header" xml:space="preserve">
-    <value>Log file path</value>
+  <data name="LogFilePathHostControl.Title" xml:space="preserve">
+    <value>Logging</value>
     <comment>SettingsPage</comment>
   </data>
   <data name="LogFilePathNokTextBlock.Text" xml:space="preserve">
@@ -881,5 +881,16 @@ You can easily access your user file via settings and see an example of a valid 
   <data name="UserMessage_TooManyActions" xml:space="preserve">
     <value>Too many actions in history, a limited number of actions have been restored.</value>
     <comment>User messages</comment>
+  </data>
+  <data name="LogFileTextBox.Header" xml:space="preserve">
+    <value>Write a path, it will be saved a few seconds after you stop writing.</value>
+    <comment>SettingsPage</comment>
+  </data>
+  <data name="LogFileTextBox.PlaceholderText" xml:space="preserve">
+    <value>Logging file path</value>
+    <comment>SettingsPage</comment>
+  </data>
+  <data name="LogFilePathHostControl.Subtitle" xml:space="preserve">
+    <value>Restart required</value>
   </data>
 </root>

--- a/ClipboardManager/Resources.resw
+++ b/ClipboardManager/Resources.resw
@@ -862,4 +862,24 @@ You can easily access your user file via settings and see an example of a valid 
     <value>{} triggers loaded.</value>
     <comment>UserMessage</comment>
   </data>
+  <data name="HeaderActionsTextBlock.Text" xml:space="preserve">
+    <value>Actions</value>
+    <comment>SettingsPage</comment>
+  </data>
+  <data name="HeaderClipboardTextBlock.Text" xml:space="preserve">
+    <value>Clipboard</value>
+    <comment>SettingsPage</comment>
+  </data>
+  <data name="ClipboardEventingHostControl.Title" xml:space="preserve">
+    <value>Clipboard events</value>
+    <comment>SettingsPage</comment>
+  </data>
+  <data name="ClipboardEventingHostControl.Subtitle" xml:space="preserve">
+    <value>Use Windows native events</value>
+    <comment>SettingsPage</comment>
+  </data>
+  <data name="UserMessage_TooManyActions" xml:space="preserve">
+    <value>Too many actions in history, a limited number of actions have been restored.</value>
+    <comment>User messages</comment>
+  </data>
 </root>

--- a/ClipboardManager/SettingsPage.cpp
+++ b/ClipboardManager/SettingsPage.cpp
@@ -86,7 +86,7 @@ namespace winrt::ClipboardManager::implementation
         clip::utils::StartupTask startupTask{};
         AutoStartToggleSwitch().IsOn(startupTask.isTaskRegistered());
 
-        SaveMatchingResultsToggleSwitch().IsOn(settings.get<bool>(L"SaveMatchingResults").value_or(false));
+        SaveMatchingResultsToggleSwitch().IsOn(settings.get<bool>(L"SaveMatchingResults").value_or(true));
         StartMinimizedToggleSwitch().IsOn(settings.get<bool>(L"StartWindowMinimized").value_or(false));
         HideAppWindowToggleSwitch().IsOn(settings.get<bool>(L"HideAppWindow").value_or(false));
         NotificationsToggleSwitch().IsOn(settings.get<bool>(L"NotificationsEnabled").value_or(true));
@@ -129,6 +129,8 @@ namespace winrt::ClipboardManager::implementation
             UserFilePathTextBlock().FontStyle(Windows::UI::Text::FontStyle::Normal);
         }
 
+        // Developper :
+        LoggingToggleSwitch().IsOn(settings.get<bool>(L"LoggingEnabled").value_or(false));
         auto logFilePath = settings.get<std::filesystem::path>(L"LogFilePath");
         if (logFilePath && std::filesystem::exists(logFilePath.value()))
         {
@@ -459,6 +461,10 @@ namespace winrt::ClipboardManager::implementation
         check_loaded(loaded);
         updateSetting(sender, L"InterpretWMClipboardMessages");
     }
+
+    void SettingsPage::LoggingToggleSwitch_Toggled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e)
+    {
+        check_loaded(loaded);
+        updateSetting(sender, L"LoggingEnabled");
+    }
 }
-
-

--- a/ClipboardManager/SettingsPage.cpp
+++ b/ClipboardManager/SettingsPage.cpp
@@ -95,7 +95,6 @@ namespace winrt::ClipboardManager::implementation
         IgnoreCaseToggleSwitch().IsOn(settings.get<bool>(L"RegexIgnoreCase").value_or(false));
         selectComboBoxItem(RegexModeComboBox(), settings.get<int32_t>(L"TriggerMatchMode").value_or(0));
         AddDuplicatedActionsToggleSwitch().IsOn(settings.get<bool>(L"AddDuplicatedActions").value_or(true));
-        ImportClipboardHistoryToggleSwitch().IsOn(settings.get<bool>(L"ImportClipboardHistory").value_or(false));
         selectComboBoxItem(ClipboardActionViewClickComboBox(), settings.get<int32_t>(L"ClipboardActionClick").value_or(0));
 
         // Notifications:
@@ -118,6 +117,10 @@ namespace winrt::ClipboardManager::implementation
         AllowMinimizeToggleSwitch().IsOn(settings.get<bool>(L"AllowWindowMinimize").value_or(true));
         OverlayResizableToggleSwitch().IsOn(settings.get<bool>(L"OverlayIsResizable").value_or(true));
         OverlayShownInSwitcherToggleSwitch().IsOn(settings.get<bool>(L"OverlayShownInSwitchers").value_or(true));
+
+        // Clipboard eventing:
+        ImportClipboardHistoryToggleSwitch().IsOn(settings.get<bool>(L"ImportClipboardHistory").value_or(false));
+        ClipboardEventingToggleSwitch().IsOn(settings.get<bool>(L"InterpretWMClipboardMessages").value_or(false));
 
         auto userFilePath = settings.get<hstring>(L"UserFilePath");
         if (userFilePath.has_value())
@@ -450,4 +453,12 @@ namespace winrt::ClipboardManager::implementation
         logger.debug(L"Saving user file path (timeout).");
         settings.insert<std::wstring_view>(L"LogFilePath", LogFileTextBox().Text());
     }
+
+    void SettingsPage::ClipboardEventingToggleSwitch_Toggled(win::IInspectable const& sender, xaml::RoutedEventArgs const&)
+    {
+        check_loaded(loaded);
+        updateSetting(sender, L"InterpretWMClipboardMessages");
+    }
 }
+
+

--- a/ClipboardManager/SettingsPage.h
+++ b/ClipboardManager/SettingsPage.h
@@ -67,6 +67,7 @@ namespace winrt::ClipboardManager::implementation
         void LogFileTextBox_TextChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::TextChangedEventArgs const& e);
         void DoubleAnimation_Completed_1(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::Foundation::IInspectable const& e);
         void ClipboardEventingToggleSwitch_Toggled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
+        void LoggingToggleSwitch_Toggled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
     };
 }
 

--- a/ClipboardManager/SettingsPage.h
+++ b/ClipboardManager/SettingsPage.h
@@ -66,6 +66,7 @@ namespace winrt::ClipboardManager::implementation
         void ClipboardActionViewClickComboBox_SelectionChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::SelectionChangedEventArgs const& e);
         void LogFileTextBox_TextChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::Controls::TextChangedEventArgs const& e);
         void DoubleAnimation_Completed_1(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::Foundation::IInspectable const& e);
+        void ClipboardEventingToggleSwitch_Toggled(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
     };
 }
 

--- a/ClipboardManager/SettingsPage.xaml
+++ b/ClipboardManager/SettingsPage.xaml
@@ -605,7 +605,11 @@
                     </Storyboard>
                 </Expander.Resources>
                 <Expander.Header>
-                    <clip:HostControl x:Uid="LogFilePathHostControl" Background="Transparent" BorderThickness="0" Padding="0"/>
+                    <clip:HostControl x:Uid="LogFilePathHostControl" Background="Transparent" BorderThickness="0" Padding="0">
+                        <clip:HostControl.HostContent>
+                            <ToggleSwitch x:Name="LoggingToggleSwitch" Style="{StaticResource FlippedToggleSwitchStyle}" Toggled="LoggingToggleSwitch_Toggled"/>
+                        </clip:HostControl.HostContent>
+                    </clip:HostControl>
                 </Expander.Header>
 
                 <Grid Padding="15,10,15,15" ColumnSpacing="15">
@@ -613,11 +617,12 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <TextBox x:Name="LogFileTextBox" TextWrapping="Wrap" TextChanged="LogFileTextBox_TextChanged" VerticalAlignment="Center"/>
+                    <TextBox x:Name="LogFileTextBox" x:Uid="LogFileTextBox" TextWrapping="Wrap" TextChanged="LogFileTextBox_TextChanged" VerticalAlignment="Center"
+                             IsEnabled="{x:Bind LoggingToggleSwitch.IsOn, Mode=OneWay}"/>
 
                     <Viewbox Height="15" Grid.Column="1" VerticalAlignment="Center">
                         <!--<FontIcon Glyph="&#xe823;"/>-->
-                        <ProgressRing x:Name="SaveProgressRing" Value="1" Maximum="1" IsIndeterminate="False"/>
+                        <ProgressRing x:Name="SaveProgressRing" Value="1" Maximum="1" IsIndeterminate="False" IsEnabled="{x:Bind LoggingToggleSwitch.IsOn, Mode=OneWay}"/>
                     </Viewbox>
                 </Grid>
             </Expander>

--- a/ClipboardManager/SettingsPage.xaml
+++ b/ClipboardManager/SettingsPage.xaml
@@ -306,18 +306,26 @@
                     </ComboBox>
                 </clip:HostControl.HostContent>
             </clip:HostControl>
+            <!--#endregion-->
 
-            <clip:HostControl x:Uid="AddDuplicatedActionsHostControl">
-                <clip:HostControl.HostContent>
-                    <ToggleSwitch x:Name="AddDuplicatedActionsToggleSwitch" Toggled="AddDuplicatedActionsToggleSwitch_Toggled"/>
-                </clip:HostControl.HostContent>
-            </clip:HostControl>
+            <!--#region Clipboard -->
+            <TextBlock x:Uid="HeaderClipboardTextBlock" Style="{ThemeResource CaptionTextBlockStyle}" Opacity="0.6" Margin="0,12,0,0"/>
 
             <clip:HostControl x:Uid="ImportClipboardHistoryHostControl">
                 <clip:HostControl.HostContent>
                     <ToggleSwitch x:Name="ImportClipboardHistoryToggleSwitch" Toggled="ImportClipboardHistoryToggleSwitch_Toggled"/>
                 </clip:HostControl.HostContent>
             </clip:HostControl>
+            
+            <clip:HostControl x:Uid="ClipboardEventingHostControl">
+                <clip:HostControl.HostContent>
+                    <ToggleSwitch x:Name="ClipboardEventingToggleSwitch" Toggled="ClipboardEventingToggleSwitch_Toggled"/>
+                </clip:HostControl.HostContent>
+            </clip:HostControl>
+            <!--#endregion-->
+
+            <!--#region Actions options-->
+            <TextBlock x:Uid="HeaderActionsTextBlock" Style="{ThemeResource CaptionTextBlockStyle}" Opacity="0.6" Margin="0,12,0,0"/>
 
             <clip:HostControl x:Uid="ClipboardActionViewClickHostControl">
                 <clip:HostControl.HostContent>
@@ -327,9 +335,15 @@
                     </ComboBox>
                 </clip:HostControl.HostContent>
             </clip:HostControl>
+
+            <clip:HostControl x:Uid="AddDuplicatedActionsHostControl">
+                <clip:HostControl.HostContent>
+                    <ToggleSwitch x:Name="AddDuplicatedActionsToggleSwitch" Toggled="AddDuplicatedActionsToggleSwitch_Toggled"/>
+                </clip:HostControl.HostContent>
+            </clip:HostControl>
             <!--#endregion-->
-
-
+            
+            
             <!--#region Browser -->
             <TextBlock x:Uid="HeaderBrowserTextBlock" Style="{ThemeResource CaptionTextBlockStyle}" Opacity="0.6" Margin="0,12,0,0"/>
             <Expander Style="{StaticResource ExpanderStyle}">

--- a/ClipboardManager/lib/ClipboardTrigger.cpp
+++ b/ClipboardManager/lib/ClipboardTrigger.cpp
@@ -96,19 +96,13 @@ namespace clip
             boost::property_tree::read_xml(userFilePath.string(), tree, boost::property_tree::xml_parser::trim_whitespace);
 
             // Erase the tree so I dont induce conflicts.
-            auto settingsNode = tree.get_child_optional(L"settings");
-            if (settingsNode.has_value())
+            auto&& triggersNode = tree.put_child(L"settings.triggers", boost::property_tree::wptree());
+            for (auto&& trigger : triggersList)
             {
-                auto&& triggersNode = tree.put_child(L"settings.triggers", boost::property_tree::wptree());
-
-                // For each trigger, create an empty trigger node for the trigger object to save it-self.
-                for (auto&& trigger : triggersList)
-                {
-                    triggersNode.push_front({ L"trigger", trigger.serialize() });
-                }
-
-                boost::property_tree::write_xml(userFilePath.string(), tree, std::locale(), boost::property_tree::xml_writer_settings<std::wstring>('\t', 1));
+                triggersNode.push_front({ L"trigger", trigger.serialize() });
             }
+
+            boost::property_tree::write_xml(userFilePath.string(), tree, std::locale(), boost::property_tree::xml_writer_settings<std::wstring>('\t', 1));
         }
         else
         {

--- a/ClipboardManager/lib/ClipboardTrigger.cpp
+++ b/ClipboardManager/lib/ClipboardTrigger.cpp
@@ -219,10 +219,10 @@ namespace clip
                 auto str = matchResults[1].str();
                 return std::vformat(_format, std::make_wformat_args(str));
             }
-
-#ifdef _DEBUG
-            logger.info(L"Failed to format string with regex match results.");
-#endif
+            else
+            {
+                logger.debug(L"Failed to format string with regex match results.");
+            }
         }
 
         return std::vformat(_format, std::make_wformat_args(string));

--- a/ClipboardManager/lib/Settings.hpp
+++ b/ClipboardManager/lib/Settings.hpp
@@ -92,7 +92,7 @@ namespace clip
 
         std::vector<std::pair<std::wstring, clip::reg_types>> getAll();
         void clear();
-        void remove(const key_t& key);
+        bool remove(const key_t& key);
         bool contains(const key_t& key);
 
         template<concepts::StringInsertable T>
@@ -137,7 +137,6 @@ namespace clip
 #ifdef ENABLE_LOGGING
         utils::Logger logger{ L"Settings" };
 #endif // ENABLE_LOGGING
-
 
         void clearKey(HKEY hkey);
         wil::shared_hkey createSubKey(const key_t& key);

--- a/ClipboardManager/lib/implementation/Settings_implementation.hpp
+++ b/ClipboardManager/lib/implementation/Settings_implementation.hpp
@@ -53,9 +53,9 @@ namespace clip
         clearKey(hKey.get());
     }
 
-    inline void Settings::remove(const key_t& key)
+    inline bool Settings::remove(const key_t& key)
     {
-        RegDeleteValueW(hKey.get(), key.c_str());
+        return RegDeleteValueW(hKey.get(), key.c_str()) == ERROR_SUCCESS;
     }
 
     inline bool Settings::contains(const key_t& key)

--- a/ClipboardManager/lib/utils/AppVersion.cpp
+++ b/ClipboardManager/lib/utils/AppVersion.cpp
@@ -1,8 +1,8 @@
 #include "pch.h"
 #include "AppVersion.hpp"
 
-constexpr auto APP_VERSION = L"1.4.4";
-constexpr auto APP_VERSION_NAME = L"Eucalyptus";
+constexpr auto APP_VERSION = L"1.4.8";
+constexpr auto APP_VERSION_NAME = L"Chêne";
 
 namespace clip::utils
 {

--- a/ClipboardManager/lib/utils/AppVersion.cpp
+++ b/ClipboardManager/lib/utils/AppVersion.cpp
@@ -1,6 +1,9 @@
 #include "pch.h"
 #include "AppVersion.hpp"
 
+constexpr auto APP_VERSION = L"1.4.3";
+constexpr auto APP_VERSION_NAME = L"Chêne";
+
 namespace clip::utils
 {
     AppVersion::AppVersion() :

--- a/ClipboardManager/lib/utils/AppVersion.cpp
+++ b/ClipboardManager/lib/utils/AppVersion.cpp
@@ -1,8 +1,8 @@
 #include "pch.h"
 #include "AppVersion.hpp"
 
-constexpr auto APP_VERSION = L"1.4.3";
-constexpr auto APP_VERSION_NAME = L"Chêne";
+constexpr auto APP_VERSION = L"1.4.4";
+constexpr auto APP_VERSION_NAME = L"Eucalyptus";
 
 namespace clip::utils
 {

--- a/ClipboardManager/lib/utils/AppVersion.hpp
+++ b/ClipboardManager/lib/utils/AppVersion.hpp
@@ -1,9 +1,6 @@
 #pragma once
 #include <string>
 
-constexpr const wchar_t* APP_VERSION = L"1.4.0";
-constexpr const wchar_t* APP_VERSION_NAME = L"Chêne";
-
 namespace clip::utils
 {
     class AppVersion

--- a/ClipboardManager/lib/utils/Logger.cpp
+++ b/ClipboardManager/lib/utils/Logger.cpp
@@ -11,6 +11,8 @@
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/trivial.hpp>
 
+#include <winrt/Windows.Storage.h>
+
 #include <iostream>
 #include <format>
 #include <mutex>
@@ -138,16 +140,18 @@ namespace clip::utils
 
     void Logger::initBoostLogging()
     {
-        std::filesystem::path logFileName{ "cm_log%N.log" };
-        auto logFilePath = clip::Settings().get<std::filesystem::path>(L"LogFilePath");
-        if (logFilePath)
+        std::filesystem::path documentsLibPath{ std::wstring(winrt::Windows::Storage::KnownFolders::DocumentsLibrary().Path()) };
+        auto logFilePath = documentsLibPath / L"cm_log%N.log";
+
+        auto userLogFilePath = clip::Settings().get<std::filesystem::path>(L"LogFilePath");
+        if (userLogFilePath)
         {
-            logFileName = logFilePath.value() / logFileName;
+            logFilePath = userLogFilePath.value() / logFilePath;
         }
 
         auto&& fileLog = boost::log::add_file_log
         (
-            boost::log::file_name = logFileName.string(),
+            boost::log::file_name = logFilePath.string(),
             boost::log::format = "[%TimeStamp%]: %Message%",
             boost::log::auto_flush = true
         );

--- a/ClipboardManager/lib/utils/Logger.cpp
+++ b/ClipboardManager/lib/utils/Logger.cpp
@@ -89,75 +89,73 @@ namespace clip::utils
         }
 
         auto&& formattedName = formatClassName(className);
-        
-        if constexpr (USE_LOG_FILE)
-        {
-            BOOST_LOG(logger) << formattedName << clip::utils::to_string(message);
-        }
-
         switch (severity)
         {
             case LogSeverity::Debug:
             {
-                std::wcout << formattedName << L"  DEBUG:  " << message << std::endl;
+                std::wcout << std::format(L"{}  DEBUG:  {}\n", formattedName, message);
                 break;
             }
 
             case LogSeverity::Info:
             {
-                std::wcout << formattedName << L"  INFO:   " << message << std::endl;
+                std::wcout << std::format(L"{}  INFO:   {}\n", formattedName, message);
                 break;
             }
 
             case LogSeverity::Error:
             {
-                std::wcout << formattedName << L"  ERROR:  " << message << std::endl;
+                std::wcout << std::format(L"{}  ERROR:  {}\n", formattedName, message);
                 break;
             }
 
             case LogSeverity::None:
             default:
             {
-                std::wcout << formattedName << L"  LOG:    " << message << std::endl;
+                std::wcout << std::format(L"{}  LOG:    {}\n", formattedName, message);
                 break;
             }
         }
 
+        if constexpr (USE_LOG_FILE)
+        {
+            BOOST_LOG(logger) << formattedName << L' ' << clip::utils::to_string(message);
+        }
     }
 
 
-    std::wstring Logger::formatClassName(const std::wstring& className) const
+    std::wstring Logger::formatClassName(const std::wstring_view& className) const
     {
-        const std::wstring padding = std::wstring(maxClassNameLength - className.size(), L' ');
-
-        auto&& formattedName = std::vformat(L"[{}]{}", std::make_wformat_args(
-            className,
-            padding
-        ));
-
-        return formattedName;
+        return std::format(
+            L"[{}]{}",
+            className, std::wstring(maxClassNameLength - className.size(), L' ')
+        );
     }
 
     void Logger::initBoostLogging()
     {
-        std::filesystem::path documentsLibPath{ std::wstring(winrt::Windows::Storage::KnownFolders::DocumentsLibrary().Path()) };
-        auto logFilePath = documentsLibPath / L"cm_log%N.log";
-
-        auto userLogFilePath = clip::Settings().get<std::filesystem::path>(L"LogFilePath");
-        if (userLogFilePath)
+        clip::Settings settings{};
+        if (settings.get<bool>(L"LoggingEnabled").value_or(false))
         {
-            logFilePath = userLogFilePath.value() / logFilePath;
+            std::filesystem::path documentsLibPath{ std::wstring(winrt::Windows::Storage::KnownFolders::DocumentsLibrary().Path()) };
+            auto logFilePath = documentsLibPath / L"cm_log%N.log";
+
+            auto userLogFilePath = settings.get<std::filesystem::path>(L"LogFilePath");
+            if (userLogFilePath)
+            {
+                logFilePath = userLogFilePath.value() / logFilePath;
+            }
+
+            auto&& fileLog = boost::log::add_file_log
+            (
+                boost::log::file_name = logFilePath.string(),
+                boost::log::format = "[%TimeStamp%]: %Message%",
+                boost::log::auto_flush = true
+            );
+
+            boost::log::add_common_attributes();
+
+            boostLoggerInitialized = (fileLog != nullptr);
         }
-
-        auto&& fileLog = boost::log::add_file_log
-        (
-            boost::log::file_name = logFilePath.string(),
-            boost::log::format = "[%TimeStamp%]: %Message%",
-            boost::log::auto_flush = true
-        );
-
-        boost::log::add_common_attributes();
-
-        boostLoggerInitialized = (fileLog != nullptr);
     }
 }

--- a/ClipboardManager/lib/utils/Logger.cpp
+++ b/ClipboardManager/lib/utils/Logger.cpp
@@ -24,7 +24,7 @@ namespace boost::log
 
 namespace clip::utils
 {
-    constexpr bool USE_LOG_FILE = true;
+    constexpr bool USE_LOG_FILE = false;
 
     std::atomic_size_t Logger::maxClassNameLength = 0;
     std::atomic_bool Logger::boostLoggerInitialized = false;
@@ -40,7 +40,14 @@ namespace clip::utils
             static std::once_flag flag{};
             std::call_once(flag, [this]()
             {
-                initBoostLogging();
+                try
+                {
+                    initBoostLogging();
+                }
+                catch (std::exception& except)
+                {
+                    error("Impossible to initialize boost logging: " + std::string(except.what()));
+                }
             });
         }
     }

--- a/ClipboardManager/lib/utils/Logger.hpp
+++ b/ClipboardManager/lib/utils/Logger.hpp
@@ -35,7 +35,7 @@ namespace clip::utils
         std::wstring className{};
         boost::log::sources::logger logger{};
 
-        std::wstring formatClassName(const std::wstring& className) const;
+        std::wstring formatClassName(const std::wstring_view& className) const;
         void initBoostLogging();
     };
 }

--- a/ClipboardManager/lib/utils/helpers.cpp
+++ b/ClipboardManager/lib/utils/helpers.cpp
@@ -258,3 +258,11 @@ namespace clip::utils
         return wss.str();
     }
 }
+
+namespace clip::utils
+{
+    std::wstring ClipboardSourceFinder::findSource(std::wstring_view && value)
+    {
+        return std::wstring();
+    }
+}

--- a/ClipboardManager/lib/utils/helpers.hpp
+++ b/ClipboardManager/lib/utils/helpers.hpp
@@ -161,3 +161,17 @@ namespace clip::utils
         std::wstring format(winrt::Windows::ApplicationModel::DataTransfer::DataPackageView& content);
     };
 }
+
+namespace clip::utils
+{
+    class ClipboardSourceFinder
+    {
+    public:
+        ClipboardSourceFinder() = default;
+
+        std::wstring findSource(std::wstring_view&& value);
+
+    private:
+        std::vector<std::pair<boost::wregex, const std::wstring>> sources{};
+    };
+}

--- a/ClipboardManagerBundle/Bundle.wxs
+++ b/ClipboardManagerBundle/Bundle.wxs
@@ -5,7 +5,7 @@
         Name="$(var.PackageFriendlyName)" 
         Manufacturer="$(var.Manufacturer)" 
         Version="$(var.Version)" 
-        UpgradeCode="87cc44b6-bdbb-4e11-b7de-01a3b7f43efe"
+        UpgradeCode="$(var.UpgradeCode)"
         AboutUrl="https://github.com/psyKomicron/ClipboardManager">
         <BootstrapperApplication>
             <bal:WixStandardBootstrapperApplication LicenseUrl="https://www.gnu.org/licenses/gpl-3.0.html" Theme="hyperlinkLicense" />
@@ -30,23 +30,7 @@
         <Variable Name="VCRUNTIME_VER" Type="version" Value="14.42.34433.0" />
         <!--<Variable Name="WASDKRUNTIME_VER" Type="version" Value="6000.318.2304.0" />-->
 
-        <Chain DisableSystemRestore="yes">
-            <!-- TODO: Define the list of chained packages. -->
-            <!--<ExePackage
-                Id="WASDK_1_6"
-                DisplayName="Microsoft Windows App SDK Runtime"
-                Description="Microsoft Windows App SDK Runtime installer."
-                SourceFile="windowsappruntimeinstall-x64.exe"
-                Cache="remove"
-                PerMachine="yes"
-                Permanent="yes"
-                Protocol="burn"
-                Compressed="yes"
-                Vital="yes"
-                DetectCondition="VersionNT64 AND (ARCH_NAME = &quot;AMD64&quot;)"
-                InstallArguments="-q"
-                RepairArguments="-r"/>-->
-
+        <Chain>
             <ExePackage
                 Id="VC_REDIST_X64"
                 DisplayName="Microsoft Visual C++ 2015-2022 Redistributable (x64)"

--- a/ClipboardManagerWixPackage/Include.wxi
+++ b/ClipboardManagerWixPackage/Include.wxi
@@ -4,5 +4,6 @@
     <?define PackageFriendlyName = "Clipboard Manager V2"?>
     <?define Manufacturer = "psyKomicron"?>
     <?define Name = "ClipboardManagerV2"?>
-    <?define Version = "1.3.5.0"?>
+    <?define Version = "1.4.3.0"?>
+    <?define UpgradeCode = "19af4dd0-d520-457f-97dd-333b9a8be1cb"?>
 </Include>

--- a/ClipboardManagerWixPackage/Include.wxi
+++ b/ClipboardManagerWixPackage/Include.wxi
@@ -4,6 +4,6 @@
     <?define PackageFriendlyName = "Clipboard Manager V2"?>
     <?define Manufacturer = "psyKomicron"?>
     <?define Name = "ClipboardManagerV2"?>
-    <?define Version = "1.4.3.0"?>
+    <?define Version = "1.4.8.0"?>
     <?define UpgradeCode = "19af4dd0-d520-457f-97dd-333b9a8be1cb"?>
 </Include>

--- a/ClipboardManagerWixPackage/Package.wxs
+++ b/ClipboardManagerWixPackage/Package.wxs
@@ -1,6 +1,6 @@
 ﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <?include Include.wxi?>
-    <Package Name="$(var.PackageFriendlyName)" Manufacturer="psyKomicron" Version="1.0.0.0" UpgradeCode="19af4dd0-d520-457f-97dd-333b9a8be1cb">
+    <Package Name="$(var.PackageFriendlyName)" Manufacturer="psyKomicron" Version="$(var.Version)" UpgradeCode="$(var.UpgradeCode)">
         <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeError)" />
 
         <MediaTemplate EmbedCab="yes" />

--- a/ClipboardManagerWixPackage/WasdkInstaller.wxs
+++ b/ClipboardManagerWixPackage/WasdkInstaller.wxs
@@ -12,7 +12,7 @@
             Impersonate="no"
             Return="check"
             FileRef="InstallerExe"
-            ExeCommand="-q"/>
+            ExeCommand=""/>
 
         <InstallExecuteSequence>
             <Custom Action="INSTALL_WASDK" After="InstallFinalize" Condition="NOT Installed"/>

--- a/ClipboardManagerWixPackage/WasdkInstaller.wxs
+++ b/ClipboardManagerWixPackage/WasdkInstaller.wxs
@@ -9,7 +9,6 @@
 
         <CustomAction 
             Id="INSTALL_WASDK"
-            Execute="immediate"
             Impersonate="no"
             Return="check"
             FileRef="InstallerExe"


### PR DESCRIPTION
## New
`v1.4.7`
- Log file not enabled by default, can be enabled in settings.

`v1.4.0`
- Log file (location can be modified in settings->dev options).

`v1.3.5`
- Added setting to change "show window" shortcut (by default alt + space).
- Overlay mode (button on the top left of the window) now hides the application's window. When enabled the application will behave like a system overlay, being shown when hitting the "Show window" shortcut and hiding after losing focus.
    - If the hot key/shortcut fails to be enabled, the application will not hide.
- Search bar in actions page.

## Changes & Fixes
`v1.4.8`
- `Logger` compile time string formatting (`std::format` and not `std::vformat`).
- Application no longer displays "Logging backend not initialized" if the user hasn't enabled logging.

`v1.4.5`
- Added descriptions for the app log file path text box.
- Fixed possible bug duplicating buttons when `ClipboardActionView` is loaded/unloaded by the `ScrollViewer` virtualization.
- Improved start up experience for users when the app is missing a user file :
    - File will be created empty when the user clicks the "Create" button.
    - Upon closing, the app will write to the file any actions or triggers (even if none are created, a node will be created).
    - If the file is emptied out by the user, or the app fails to save it a message will be shown to inform the user.

`v1.4.4`
- Moved log file to `~/Documents/`.
- Messages bar now displays the last message instead of the first.
- Improved settings category organization.

`v1.4.3`
- Removed log file as it crashes the application.

`v1.4.0`
- Changed message on startup when no triggers are loaded :
    - If no user file has been saved, info bar prompting to create/locate the user file.
    - If a user file has been saved, warning message saying no triggers have been loaded.
- Added message when the logger file hasn't been initialized correctly.
- User file saving fix.